### PR TITLE
arg/ret only types, empty header bugfix, arbitrary struct tags

### DIFF
--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -30,8 +30,10 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/desertbit/orbit/examples/simple/hello"
 	"github.com/desertbit/orbit/pkg/client"
@@ -66,15 +68,32 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := c.Test(context.Background())
+		ret, err := c.Test(context.Background(), hello.TestArg{S: "testarg"})
 		if err != nil {
 			log.Fatalln(err)
 		}
+
+		fmt.Printf("Test: %s, %s\n", ret.Name, ret.Ts.String())
 	}()
 
-	err = c.SayHi(context.Background(), &hello.SayHiArg{Name: "Wastl"})
+	ret, err := c.SayHi(context.Background(), hello.SayHiArg{Name: "Wastl", Ts: time.Now()})
 	if err != nil {
 		log.Fatalln(err)
+	}
+	fmt.Printf("SayHi: %+v\n", ret.Res)
+
+	stream, err := c.ClockTime(context.Background())
+	if err != nil {
+		log.Fatalln(err)
+	}
+	for i := 0; i < 3; i++ {
+		var arg hello.ClockTimeRet
+		arg, err = stream.Read()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		fmt.Printf("ClockTime: %s\n", arg.Ts.String())
 	}
 
 	wg.Wait()

--- a/examples/simple/hello/hello.orbit
+++ b/examples/simple/hello/hello.orbit
@@ -8,11 +8,11 @@ errors {
 service {
     call sayHi {
         arg: {
-            name string `validation:"required,min=1"`
+            name string `validate:"required,min=1"`
             ts time
         }
         ret: {
-            res []int `validation:"required,min=1"`
+            res []int `validate:"required,min=1"`
         }
     }
 
@@ -22,7 +22,7 @@ service {
             s string
         }
         ret: {
-            name string `validation:"required,min=1`
+            name string `validate:"required,min=1"`
             ts time
         }
         timeout: 500ms
@@ -37,16 +37,16 @@ service {
 
     stream clockTime {
         ret: {
-            ts time `validation:"required`
+            ts time `validate:"required"`
         }
     }
 }
 
 type info {
-    name    string `validation:"required,min=1`
-    age     int    `validation:"required,min=1,max=155`
-    locale  string `validation:"required,len=5`
-    address string `validation:"omitempty`
+    name    string `validate:"required,min=1"`
+    age     int    `validate:"required,min=1,max=155"`
+    locale  string `validate:"required,len=5"`
+    address string `validate:"omitempty"`
 }
 
 enum vehicle {

--- a/examples/simple/hello/hello.orbit
+++ b/examples/simple/hello/hello.orbit
@@ -8,14 +8,22 @@ errors {
 service {
     call sayHi {
         arg: {
-            name string 'required,min=1'
+            name string `validation:"required,min=1"`
+            ts time
+        }
+        ret: {
+            res []int `validation:"required,min=1"`
         }
     }
 
     call test {
         async
+        arg: {
+            s string
+        }
         ret: {
-            name string 'required,min=1'
+            name string `validation:"required,min=1`
+            ts time
         }
         timeout: 500ms
         maxRetSize: 10K
@@ -28,15 +36,17 @@ service {
     }
 
     stream clockTime {
-        ret: time 'required'
+        ret: {
+            ts time `validation:"required`
+        }
     }
 }
 
 type info {
-    name    string 'required,min=1'
-    age     int    'required,min=1,max=155'
-    locale  string 'required,len=5'
-    address string 'omitempty'
+    name    string `validation:"required,min=1`
+    age     int    `validation:"required,min=1,max=155`
+    locale  string `validation:"required,len=5`
+    address string `validation:"omitempty`
 }
 
 enum vehicle {

--- a/examples/simple/hello/hello_msgp_gen.go
+++ b/examples/simple/hello/hello_msgp_gen.go
@@ -7,6 +7,109 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *ClockTimeRet) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Ts":
+			z.Ts, err = dc.ReadTime()
+			if err != nil {
+				err = msgp.WrapError(err, "Ts")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z ClockTimeRet) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Ts"
+	err = en.Append(0x81, 0xa2, 0x54, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteTime(z.Ts)
+	if err != nil {
+		err = msgp.WrapError(err, "Ts")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z ClockTimeRet) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Ts"
+	o = append(o, 0x81, 0xa2, 0x54, 0x73)
+	o = msgp.AppendTime(o, z.Ts)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ClockTimeRet) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Ts":
+			z.Ts, bts, err = msgp.ReadTimeBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Ts")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z ClockTimeRet) Msgsize() (s int) {
+	s = 1 + 3 + msgp.TimeSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *Info) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -208,6 +311,12 @@ func (z *SayHiArg) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Name")
 				return
 			}
+		case "Ts":
+			z.Ts, err = dc.ReadTime()
+			if err != nil {
+				err = msgp.WrapError(err, "Ts")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -221,9 +330,9 @@ func (z *SayHiArg) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z SayHiArg) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 1
+	// map header, size 2
 	// write "Name"
-	err = en.Append(0x81, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	err = en.Append(0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	if err != nil {
 		return
 	}
@@ -232,16 +341,29 @@ func (z SayHiArg) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Name")
 		return
 	}
+	// write "Ts"
+	err = en.Append(0xa2, 0x54, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteTime(z.Ts)
+	if err != nil {
+		err = msgp.WrapError(err, "Ts")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z SayHiArg) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 1
+	// map header, size 2
 	// string "Name"
-	o = append(o, 0x81, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = append(o, 0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	o = msgp.AppendString(o, z.Name)
+	// string "Ts"
+	o = append(o, 0xa2, 0x54, 0x73)
+	o = msgp.AppendTime(o, z.Ts)
 	return
 }
 
@@ -269,6 +391,12 @@ func (z *SayHiArg) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Name")
 				return
 			}
+		case "Ts":
+			z.Ts, bts, err = msgp.ReadTimeBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Ts")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -283,7 +411,249 @@ func (z *SayHiArg) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z SayHiArg) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name)
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 3 + msgp.TimeSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *SayHiRet) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Res":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Res")
+				return
+			}
+			if cap(z.Res) >= int(zb0002) {
+				z.Res = (z.Res)[:zb0002]
+			} else {
+				z.Res = make([]int, zb0002)
+			}
+			for za0001 := range z.Res {
+				z.Res[za0001], err = dc.ReadInt()
+				if err != nil {
+					err = msgp.WrapError(err, "Res", za0001)
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *SayHiRet) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Res"
+	err = en.Append(0x81, 0xa3, 0x52, 0x65, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Res)))
+	if err != nil {
+		err = msgp.WrapError(err, "Res")
+		return
+	}
+	for za0001 := range z.Res {
+		err = en.WriteInt(z.Res[za0001])
+		if err != nil {
+			err = msgp.WrapError(err, "Res", za0001)
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *SayHiRet) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Res"
+	o = append(o, 0x81, 0xa3, 0x52, 0x65, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Res)))
+	for za0001 := range z.Res {
+		o = msgp.AppendInt(o, z.Res[za0001])
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SayHiRet) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Res":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Res")
+				return
+			}
+			if cap(z.Res) >= int(zb0002) {
+				z.Res = (z.Res)[:zb0002]
+			} else {
+				z.Res = make([]int, zb0002)
+			}
+			for za0001 := range z.Res {
+				z.Res[za0001], bts, err = msgp.ReadIntBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Res", za0001)
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *SayHiRet) Msgsize() (s int) {
+	s = 1 + 4 + msgp.ArrayHeaderSize + (len(z.Res) * (msgp.IntSize))
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TestArg) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "S":
+			z.S, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "S")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z TestArg) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "S"
+	err = en.Append(0x81, 0xa1, 0x53)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.S)
+	if err != nil {
+		err = msgp.WrapError(err, "S")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z TestArg) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "S"
+	o = append(o, 0x81, 0xa1, 0x53)
+	o = msgp.AppendString(o, z.S)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TestArg) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "S":
+			z.S, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "S")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z TestArg) Msgsize() (s int) {
+	s = 1 + 2 + msgp.StringPrefixSize + len(z.S)
 	return
 }
 
@@ -311,6 +681,12 @@ func (z *TestRet) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Name")
 				return
 			}
+		case "Ts":
+			z.Ts, err = dc.ReadTime()
+			if err != nil {
+				err = msgp.WrapError(err, "Ts")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -324,9 +700,9 @@ func (z *TestRet) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z TestRet) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 1
+	// map header, size 2
 	// write "Name"
-	err = en.Append(0x81, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	err = en.Append(0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	if err != nil {
 		return
 	}
@@ -335,16 +711,29 @@ func (z TestRet) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Name")
 		return
 	}
+	// write "Ts"
+	err = en.Append(0xa2, 0x54, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteTime(z.Ts)
+	if err != nil {
+		err = msgp.WrapError(err, "Ts")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z TestRet) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 1
+	// map header, size 2
 	// string "Name"
-	o = append(o, 0x81, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = append(o, 0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	o = msgp.AppendString(o, z.Name)
+	// string "Ts"
+	o = append(o, 0xa2, 0x54, 0x73)
+	o = msgp.AppendTime(o, z.Ts)
 	return
 }
 
@@ -372,6 +761,12 @@ func (z *TestRet) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Name")
 				return
 			}
+		case "Ts":
+			z.Ts, bts, err = msgp.ReadTimeBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Ts")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -386,7 +781,7 @@ func (z *TestRet) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z TestRet) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name)
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 3 + msgp.TimeSize
 	return
 }
 

--- a/examples/simple/hello/hello_msgp_gen_test.go
+++ b/examples/simple/hello/hello_msgp_gen_test.go
@@ -9,6 +9,119 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+func TestMarshalUnmarshalClockTimeRet(t *testing.T) {
+	v := ClockTimeRet{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgClockTimeRet(b *testing.B) {
+	v := ClockTimeRet{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgClockTimeRet(b *testing.B) {
+	v := ClockTimeRet{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalClockTimeRet(b *testing.B) {
+	v := ClockTimeRet{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeClockTimeRet(t *testing.T) {
+	v := ClockTimeRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := ClockTimeRet{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeClockTimeRet(b *testing.B) {
+	v := ClockTimeRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeClockTimeRet(b *testing.B) {
+	v := ClockTimeRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalInfo(t *testing.T) {
 	v := Info{}
 	bts, err := v.MarshalMsg(nil)
@@ -220,6 +333,232 @@ func BenchmarkEncodeSayHiArg(b *testing.B) {
 
 func BenchmarkDecodeSayHiArg(b *testing.B) {
 	v := SayHiArg{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalSayHiRet(t *testing.T) {
+	v := SayHiRet{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgSayHiRet(b *testing.B) {
+	v := SayHiRet{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSayHiRet(b *testing.B) {
+	v := SayHiRet{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSayHiRet(b *testing.B) {
+	v := SayHiRet{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeSayHiRet(t *testing.T) {
+	v := SayHiRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := SayHiRet{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeSayHiRet(b *testing.B) {
+	v := SayHiRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeSayHiRet(b *testing.B) {
+	v := SayHiRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalTestArg(t *testing.T) {
+	v := TestArg{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTestArg(b *testing.B) {
+	v := TestArg{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTestArg(b *testing.B) {
+	v := TestArg{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTestArg(b *testing.B) {
+	v := TestArg{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTestArg(t *testing.T) {
+	v := TestArg{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := TestArg{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTestArg(b *testing.B) {
+	v := TestArg{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTestArg(b *testing.B) {
+	v := TestArg{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/examples/simple/hello/hello_orbit_gen.go
+++ b/examples/simple/hello/hello_orbit_gen.go
@@ -80,7 +80,7 @@ func _valErrCheck(err error) error {
 	if vErrs, ok := err.(validator.ValidationErrors); ok {
 		var errMsg strings.Builder
 		for _, err := range vErrs {
-			errMsg.WriteString(fmt.Sprintf("-> name: '%s', value: '%s', tag: '%s'", err.StructNamespace(), err.Value(), err.Tag()))
+			errMsg.WriteString(fmt.Sprintf("[name: '%s', value: '%s', tag: '%s']", err.StructNamespace(), err.Value(), err.Tag()))
 		}
 		return errors.New(errMsg.String())
 	}
@@ -94,23 +94,23 @@ var validate = validator.New()
 //#############//
 
 type ClockTimeRet struct {
-	Ts time.Time `validation:"required`
+	Ts time.Time `validate:"required"`
 }
 
 type Info struct {
-	Name    string `validation:"required,min=1`
-	Age     int    `validation:"required,min=1,max=155`
-	Locale  string `validation:"required,len=5`
-	Address string `validation:"omitempty`
+	Name    string `validate:"required,min=1"`
+	Age     int    `validate:"required,min=1,max=155"`
+	Locale  string `validate:"required,len=5"`
+	Address string `validate:"omitempty"`
 }
 
 type SayHiArg struct {
-	Name string `validation:"required,min=1"`
+	Name string `validate:"required,min=1"`
 	Ts   time.Time
 }
 
 type SayHiRet struct {
-	Res []int `validation:"required,min=1"`
+	Res []int `validate:"required,min=1"`
 }
 
 type TestArg struct {
@@ -118,7 +118,7 @@ type TestArg struct {
 }
 
 type TestRet struct {
-	Name string `validation:"required,min=1`
+	Name string `validate:"required,min=1"`
 	Ts   time.Time
 }
 

--- a/examples/simple/service/main.go
+++ b/examples/simple/service/main.go
@@ -36,6 +36,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"time"
 
 	"github.com/desertbit/orbit/examples/simple/hello"
 	olog "github.com/desertbit/orbit/pkg/hook/log"
@@ -98,17 +99,26 @@ func generateTLSConfig() *tls.Config {
 
 type ServiceHandler struct{}
 
-func (s *ServiceHandler) SayHi(ctx service.Context, arg *hello.SayHiArg) (err error) {
-	fmt.Println("hi")
+func (s *ServiceHandler) SayHi(ctx service.Context, arg hello.SayHiArg) (ret hello.SayHiRet, err error) {
+	fmt.Printf("handler: SayHi, %s, %s\n", arg.Name, arg.Ts.String())
+	ret = hello.SayHiRet{Res: []int{1, 2, 3}}
 	return
 }
 
-func (s *ServiceHandler) Test(ctx service.Context) (ret *hello.TestRet, err error) {
-	fmt.Println("test")
-	ret = &hello.TestRet{
-		Name: "horst",
-	}
+func (s *ServiceHandler) Test(ctx service.Context, arg hello.TestArg) (ret hello.TestRet, err error) {
+	fmt.Printf("handler: Test, %s\n", arg.S)
+	ret = hello.TestRet{Name: "horst", Ts: time.Now()}
 	return
+}
+
+func (s *ServiceHandler) ClockTime(ctx service.Context, ret *hello.ClockTimeRetWriteStream) {
+	for i := 0; i < 3; i++ {
+		err := ret.Write(hello.ClockTimeRet{Ts: time.Now()})
+		if err != nil {
+			fmt.Printf("ERROR handler.ClockTime: %v\n", err)
+			return
+		}
+	}
 }
 
 func (s *ServiceHandler) Lul(ctx service.Context, stream transport.Stream) {
@@ -116,9 +126,5 @@ func (s *ServiceHandler) Lul(ctx service.Context, stream transport.Stream) {
 }
 
 func (s *ServiceHandler) TimeStream(ctx service.Context, arg *hello.InfoReadStream) {
-	panic("implement me")
-}
-
-func (s *ServiceHandler) ClockTime(ctx service.Context, ret *hello.TimeWriteStream) {
 	panic("implement me")
 }

--- a/grml.yaml
+++ b/grml.yaml
@@ -28,10 +28,7 @@ commands:
                         deps:
                             - build.simple
                         exec: |
-                            while true
-                            do
-                                "${BINDIR}/simple-client"
-                            done
+                            "${BINDIR}/simple-client"
                     server:
                         help: run the server of the simple example application.
                         deps:
@@ -55,6 +52,6 @@ commands:
                 deps:
                     - build.orbit
                 exec: |
-                    "${BINDIR}/orbit" gen "${ROOT}/examples/simple/hello/hello.orbit"
+                    "${BINDIR}/orbit" gen --force "${ROOT}/examples/simple/hello/hello.orbit"
                     go build -o "${BINDIR}/simple-client" "${ROOT}/examples/simple/client"
                     go build -o "${BINDIR}/simple-server" "${ROOT}/examples/simple/service"

--- a/internal/codegen/ast/ast.go
+++ b/internal/codegen/ast/ast.go
@@ -66,10 +66,10 @@ type Type struct {
 }
 
 type TypeField struct {
-	Name     string
-	DataType DataType
-	ValTag   string
-	Line     int
+	Name      string
+	DataType  DataType
+	StructTag string
+	Line      int
 }
 
 type Service struct {
@@ -82,9 +82,7 @@ type Service struct {
 type Call struct {
 	Name       string
 	Arg        DataType
-	ArgValTag  string
 	Ret        DataType
-	RetValTag  string
 	Async      bool
 	Timeout    *time.Duration
 	MaxArgSize *int64
@@ -99,9 +97,7 @@ func (c *Call) NamePrv() string {
 type Stream struct {
 	Name       string
 	Arg        DataType
-	ArgValTag  string
 	Ret        DataType
-	RetValTag  string
 	MaxArgSize *int64
 	MaxRetSize *int64
 	Line       int

--- a/internal/codegen/ast/datatype.go
+++ b/internal/codegen/ast/datatype.go
@@ -57,6 +57,8 @@ const (
 type DataType interface {
 	// Returns go variable declaration.
 	Decl() string
+	// Returns go variable zero value.
+	ZeroValue() string
 	// Returns simple name.
 	Name() string
 }
@@ -71,6 +73,22 @@ func (b *BaseType) Decl() string {
 		return "time.Time"
 	}
 	return b.DataType
+}
+
+func (b *BaseType) ZeroValue() string {
+	switch b.DataType {
+	case TypeByte, TypeUInt, TypeUInt8, TypeUInt16, TypeUInt32, TypeUInt64,
+		TypeInt, TypeInt8, TypeInt16, TypeInt32, TypeInt64, TypeFloat32, TypeFloat64:
+		return "0"
+	case TypeString:
+		return `""`
+	case TypeBool:
+		return "false"
+	case TypeTime:
+		return "time.Time{}"
+	default:
+		return "unknown base type zero value"
+	}
 }
 
 func (b *BaseType) Name() string {
@@ -90,6 +108,10 @@ func (m *MapType) Decl() string {
 	return "map[" + m.Key.Decl() + "]" + m.Value.Decl()
 }
 
+func (m *MapType) ZeroValue() string {
+	return "make(" + m.Decl() + ", 0)"
+}
+
 func (m *MapType) Name() string {
 	return "Map" + strings.Title(m.Key.Name()) + strings.Title(m.Value.Name())
 }
@@ -103,6 +125,10 @@ func (a *ArrType) Decl() string {
 	return "[]" + a.Elem.Decl()
 }
 
+func (a *ArrType) ZeroValue() string {
+	return "make(" + a.Decl() + ", 0)"
+}
+
 func (a *ArrType) Name() string {
 	return "Arr" + strings.Title(a.Elem.Name())
 }
@@ -113,7 +139,11 @@ type StructType struct {
 }
 
 func (s *StructType) Decl() string {
-	return "*" + s.NamePrv
+	return s.NamePrv
+}
+
+func (s *StructType) ZeroValue() string {
+	return s.Decl() + "{}"
 }
 
 func (s *StructType) Name() string {
@@ -129,6 +159,10 @@ func (e *EnumType) Decl() string {
 	return e.NamePrv
 }
 
+func (e *EnumType) ZeroValue() string {
+	return "0"
+}
+
 func (e *EnumType) Name() string {
 	return e.NamePrv
 }
@@ -139,6 +173,10 @@ type AnyType struct {
 }
 
 func (a *AnyType) Decl() string {
+	return "unresolved any type"
+}
+
+func (a *AnyType) ZeroValue() string {
 	return "unresolved any type"
 }
 

--- a/internal/codegen/gen/gen.go
+++ b/internal/codegen/gen/gen.go
@@ -243,6 +243,23 @@ func (g *generator) writeTimeoutParam(timeout *time.Duration) {
 	g.write(",")
 }
 
+// writeValErrCheck is a helper that writes a validate error check to the generator.
+// It only does so, if the type is either a single value with a validation tag, or
+// a struct.
+func (g *generator) writeValErrCheck(dt ast.DataType, varName string) {
+	// Only call validate, if it is a struct.
+	if _, ok := dt.(*ast.StructType); !ok {
+		return
+	}
+
+	// Validate a struct.
+	g.writefLn("err = validate.Struct(%s)", varName)
+	g.errIfNilFunc(func() {
+		g.writefLn("err = %s(err)", valErrorCheck)
+		g.writeLn("return")
+	})
+}
+
 func (g *generator) errIfNil() {
 	g.writeLn("if err != nil { return }")
 }

--- a/internal/codegen/gen/gen_error.go
+++ b/internal/codegen/gen/gen_error.go
@@ -119,7 +119,7 @@ func (g *generator) genValErrCheckFunc() {
 	g.writeLn("if vErrs, ok := err.(validator.ValidationErrors); ok {")
 	g.writeLn("var errMsg strings.Builder")
 	g.writeLn("for _, err := range vErrs {")
-	g.writeLn("errMsg.WriteString(fmt.Sprintf(\"-> name: '%s', value: '%s', tag: '%s'\", err.StructNamespace(), err.Value(), err.Tag()))")
+	g.writeLn("errMsg.WriteString(fmt.Sprintf(\"[name: '%s', value: '%s', tag: '%s']\", err.StructNamespace(), err.Value(), err.Tag()))")
 	g.writeLn("}")
 	g.writeLn("return errors.New(errMsg.String())")
 	g.writeLn("}")

--- a/internal/codegen/gen/gen_service.go
+++ b/internal/codegen/gen/gen_service.go
@@ -183,7 +183,7 @@ func (g *generator) genServiceStruct(calls []*ast.Call, streams []*ast.Stream, e
 
 	// Generate the calls.
 	for _, c := range calls {
-		g.genServiceHandlerCall(c, errs)
+		g.genServiceHandlerCall(c)
 	}
 
 	// Generate the streams.

--- a/internal/codegen/parse/parser_service.go
+++ b/internal/codegen/parse/parser_service.go
@@ -154,7 +154,7 @@ func (p *parser) expectServiceCall() (c *ast.Call, err error) {
 			}
 
 			// Parse args.
-			c.Arg, c.ArgValTag, err = p.expectServiceEntryType(c.Name + "Arg")
+			c.Arg, err = p.expectServiceEntryType(c.Name + "Arg")
 			if err != nil {
 				return
 			}
@@ -172,7 +172,7 @@ func (p *parser) expectServiceCall() (c *ast.Call, err error) {
 			}
 
 			// Parse ret.
-			c.Ret, c.RetValTag, err = p.expectServiceEntryType(c.Name + "Ret")
+			c.Ret, err = p.expectServiceEntryType(c.Name + "Ret")
 			if err != nil {
 				return
 			}
@@ -270,7 +270,7 @@ func (p *parser) expectServiceStream() (s *ast.Stream, err error) {
 			}
 
 			// Parse args.
-			s.Arg, s.ArgValTag, err = p.expectServiceEntryType(s.Name + "Arg")
+			s.Arg, err = p.expectServiceEntryType(s.Name + "Arg")
 			if err != nil {
 				return
 			}
@@ -288,7 +288,7 @@ func (p *parser) expectServiceStream() (s *ast.Stream, err error) {
 			}
 
 			// Parse ret.
-			s.Ret, s.RetValTag, err = p.expectServiceEntryType(s.Name + "Ret")
+			s.Ret, err = p.expectServiceEntryType(s.Name + "Ret")
 			if err != nil {
 				return
 			}
@@ -324,7 +324,7 @@ func (p *parser) expectServiceStream() (s *ast.Stream, err error) {
 }
 
 // Returns ast.Err.
-func (p *parser) expectServiceEntryType(name string) (dt ast.DataType, valTag string, err error) {
+func (p *parser) expectServiceEntryType(name string) (dt ast.DataType, err error) {
 	// Check for an inline type definition.
 	if p.peekSymbol(token.BraceL) {
 		// The struct type is a reference to the inline type.
@@ -340,18 +340,10 @@ func (p *parser) expectServiceEntryType(name string) (dt ast.DataType, valTag st
 		return
 	}
 
-	// The entry has a normal data type.
-	dt, err = p.expectDataType()
+	// The entry has an any type.
+	dt, err = p.expectAnyType()
 	if err != nil {
 		return
-	}
-
-	// Check for a validation tag definition.
-	if p.checkSymbol(token.SingQuote) {
-		valTag, err = p.expectValTag()
-		if err != nil {
-			return
-		}
 	}
 
 	return

--- a/internal/codegen/parse/parser_type.go
+++ b/internal/codegen/parse/parser_type.go
@@ -76,9 +76,9 @@ func (p *parser) expectInlineType(name string, line int) (err error) {
 			return
 		}
 
-		// Check for a validation tag definition.
-		if p.checkSymbol(token.SingQuote) {
-			tf.ValTag, err = p.expectValTag()
+		// Check for a struct tag.
+		if p.checkSymbol(token.Backtick) {
+			tf.StructTag, err = p.expectStructTag()
 			if err != nil {
 				return
 			}
@@ -94,10 +94,10 @@ func (p *parser) expectInlineType(name string, line int) (err error) {
 }
 
 // Returns Err.
-func (p *parser) expectValTag() (valTag string, err error) {
+func (p *parser) expectStructTag() (valTag string, err error) {
 	// Expect the tag.
 	if p.empty() {
-		err = ast.NewErr(p.prevLine, "expected validation tag, but is missing")
+		err = ast.NewErr(p.prevLine, "expected struct tag, but is missing")
 		return
 	}
 	valTag = p.ct.Value
@@ -108,8 +108,8 @@ func (p *parser) expectValTag() (valTag string, err error) {
 		return
 	}
 
-	// Check for ending single quote.
-	err = p.expectSymbol(token.SingQuote)
+	// Check for ending backtick.
+	err = p.expectSymbol(token.Backtick)
 	if err != nil {
 		return
 	}

--- a/internal/codegen/resolve/resolve_service.go
+++ b/internal/codegen/resolve/resolve_service.go
@@ -76,12 +76,12 @@ func resolveCall(c *ast.Call, types []*ast.Type, enums []*ast.Enum) (err error) 
 		return
 	}
 
-	// Check, that no StructType has a validation tag.
-	if st, ok := c.Arg.(*ast.StructType); ok && c.ArgValTag != "" {
-		return ast.NewErr(st.Line, "validation tags not allowed on type references")
+	// For arg and ret, only Struct types are allowed.
+	if _, ok := c.Arg.(*ast.StructType); !ok && c.Arg != nil {
+		return ast.NewErr(c.Line, "arg must be an inline or reference type")
 	}
-	if st, ok := c.Ret.(*ast.StructType); ok && c.RetValTag != "" {
-		return ast.NewErr(st.Line, "validation tags not allowed on type references")
+	if _, ok := c.Ret.(*ast.StructType); !ok && c.Ret != nil {
+		return ast.NewErr(c.Line, "ret must be an inline or reference type")
 	}
 
 	// Check async calls and their special properties.
@@ -119,12 +119,12 @@ func resolveStream(s *ast.Stream, types []*ast.Type, enums []*ast.Enum) (err err
 		return
 	}
 
-	// Check, that no StructType has a validation tag.
-	if st, ok := s.Arg.(*ast.StructType); ok && s.ArgValTag != "" {
-		return ast.NewErr(st.Line, "validation tags not allowed on type references")
+	// For arg and ret, only Struct types are allowed.
+	if _, ok := s.Arg.(*ast.StructType); !ok && s.Arg != nil {
+		return ast.NewErr(s.Line, "arg must be an inline or reference type")
 	}
-	if st, ok := s.Ret.(*ast.StructType); ok && s.RetValTag != "" {
-		return ast.NewErr(st.Line, "validation tags not allowed on type references")
+	if _, ok := s.Ret.(*ast.StructType); !ok && s.Ret != nil {
+		return ast.NewErr(s.Line, "ret must be an inline or reference type")
 	}
 
 	// Check, that max sizes are only set, if the respective stream data is defined.

--- a/internal/codegen/resolve/resolve_test.go
+++ b/internal/codegen/resolve/resolve_test.go
@@ -43,7 +43,9 @@ version 1
 
 service {
     call c1 {
-        ret: []map[string]Ret
+        ret: {
+			ret []map[string]Ret
+		}
     }
 
     call rc1 {
@@ -54,9 +56,7 @@ service {
         }
     }
 
-    stream s1 {
-        ret: En1
-    }
+    stream s1 {}
 
     stream rs1 {
         arg: Args
@@ -84,12 +84,7 @@ var (
 	version = 1
 	c1      = &ast.Call{
 		Name: "C1",
-		Ret: &ast.ArrType{
-			Elem: &ast.MapType{
-				Key:   &ast.BaseType{DataType: ast.TypeString},
-				Value: &ast.StructType{NamePrv: "Ret"},
-			},
-		},
+		Ret:  &ast.StructType{NamePrv: "C1Ret"},
 	}
 	rc1 = &ast.Call{
 		Name: "Rc1",
@@ -98,7 +93,6 @@ var (
 	}
 	st1 = &ast.Stream{
 		Name: "S1",
-		Ret:  &ast.EnumType{NamePrv: "En1"},
 	}
 	rst1 = &ast.Stream{
 		Name: "Rs1",
@@ -111,6 +105,20 @@ var (
 	}
 
 	expTypes = []*ast.Type{
+		{
+			Name: "C1Ret",
+			Fields: []*ast.TypeField{
+				{
+					Name: "Ret",
+					DataType: &ast.ArrType{
+						Elem: &ast.MapType{
+							Key:   &ast.BaseType{DataType: ast.TypeString},
+							Value: &ast.StructType{NamePrv: "Ret"},
+						},
+					},
+				},
+			},
+		},
 		{
 			Name: "Rc1Ret",
 			Fields: []*ast.TypeField{
@@ -218,6 +226,7 @@ func requireEqualType(t *testing.T, exp, act *ast.Type) {
 	require.Len(t, exp.Fields, len(act.Fields))
 	for i, exptf := range exp.Fields {
 		require.Exactly(t, exptf.Name, act.Fields[i].Name)
+		require.Exactly(t, exptf.StructTag, act.Fields[i].StructTag)
 		requireEqualDataType(t, exptf.DataType, act.Fields[i].DataType)
 	}
 }

--- a/internal/codegen/token/reader.go
+++ b/internal/codegen/token/reader.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	ErrNewlineInSingQuoteString = errors.New("newline in single quote string")
+	ErrNewlineInBacktickString = errors.New("newline in backtick string")
 )
 
 type Reader interface {
@@ -53,7 +53,7 @@ type reader struct {
 
 	nextValue      []rune
 	nextTokenReady bool
-	singQuote      bool
+	structTag      bool
 	lines          int
 }
 
@@ -88,10 +88,10 @@ func (r *reader) Next() (t *Token, err error) {
 			return
 		}
 
-		if r.singQuote && nr != singQuote {
+		if r.structTag && nr != backtick {
 			// Newlines in single quotes are not allowed!
 			if nr == newLine {
-				err = ErrNewlineInSingQuoteString
+				err = ErrNewlineInBacktickString
 				return
 			}
 
@@ -115,9 +115,9 @@ func (r *reader) Next() (t *Token, err error) {
 			nr == colon ||
 			nr == equal ||
 			nr == hyphen ||
-			nr == singQuote {
-			if nr == singQuote {
-				r.singQuote = !r.singQuote
+			nr == backtick {
+			if nr == backtick {
+				r.structTag = !r.structTag
 			}
 
 			// Return next token first.
@@ -142,7 +142,7 @@ func (r *reader) Reset(rr io.RuneReader) {
 	r.rr = rr
 	r.nextValue = r.nextValue[:0]
 	r.nextTokenReady = false
-	r.singQuote = false
+	r.structTag = false
 	r.lines = 1
 }
 

--- a/internal/codegen/token/reader_test.go
+++ b/internal/codegen/token/reader_test.go
@@ -50,8 +50,8 @@ is some e-x123ample{ text
 
 [ to test ]{: =: } the
     tokenizer   汉字 }haha
-'[hello==:{}-[]  ' hee
-'' yaa`
+` + "`[hello==:{}-[]  `" + ` hee
+` + "``" + ` yaa`
 
 	cases := []struct {
 		val  string
@@ -80,12 +80,12 @@ is some e-x123ample{ text
 		{val: "汉字", line: 6, err: nil},
 		{val: token.BraceR, line: 6, err: nil}, // 20
 		{val: "haha", line: 6, err: nil},
-		{val: token.SingQuote, line: 7, err: nil},
+		{val: token.Backtick, line: 7, err: nil},
 		{val: "[hello==:{}-[]  ", line: 7, err: nil},
-		{val: token.SingQuote, line: 7, err: nil},
+		{val: token.Backtick, line: 7, err: nil},
 		{val: "hee", line: 7, err: nil}, // 25
-		{val: token.SingQuote, line: 8, err: nil},
-		{val: token.SingQuote, line: 8, err: nil},
+		{val: token.Backtick, line: 8, err: nil},
+		{val: token.Backtick, line: 8, err: nil},
 		{val: "yaa", line: 8, err: nil},
 		{err: io.EOF},
 	}
@@ -107,16 +107,16 @@ is some e-x123ample{ text
 func testReaderNextFail(t *testing.T) {
 	t.Parallel()
 
-	const data = `'
-test'`
+	const data = "`" + `
+test` + "`"
 
 	cases := []struct {
 		val  string
 		line int
 		err  error
 	}{
-		{val: token.SingQuote, line: 1, err: nil}, // 0
-		{val: "", line: 1, err: token.ErrNewlineInSingQuoteString},
+		{val: token.Backtick, line: 1, err: nil}, // 0
+		{val: "", line: 1, err: token.ErrNewlineInBacktickString},
 	}
 	tr := token.NewReader(strings.NewReader(data))
 

--- a/internal/codegen/token/token.go
+++ b/internal/codegen/token/token.go
@@ -49,8 +49,8 @@ const (
 	hyphen = '-'
 	Hyphen = string(hyphen)
 
-	singQuote = '\''
-	SingQuote = string(singQuote)
+	backtick = '`'
+	Backtick = string(backtick)
 
 	newLine = '\n'
 )

--- a/pkg/client/context.go
+++ b/pkg/client/context.go
@@ -62,6 +62,7 @@ func newContext(ctx context.Context, s Session) *clientContext {
 	return &clientContext{
 		Context: ctx,
 		s:       s,
+		header:  make(map[string][]byte),
 	}
 }
 
@@ -74,9 +75,6 @@ func (c *clientContext) Session() Session {
 }
 
 func (c *clientContext) SetHeader(key string, data []byte) {
-	if c.header == nil {
-		c.header = make(map[string][]byte)
-	}
 	c.header[key] = data
 }
 


### PR DESCRIPTION
This PR fixes multiple things at once:  
- Structs in the generated code are no longer pointers
- Removes any basic or enum types from arg/ret and only allows structs there
- Allows arbitrary go struct tags instead of just the ones for validation
- Fixes an issue where streams could not be opened, if no header was set. This is fixed in the callContext.

closes #43 
closes #44