### PR TITLE
Improved codegen arg/ret-stream and split it up into client/service related structs #59

### DIFF
--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -96,5 +96,26 @@ func main() {
 		fmt.Printf("ClockTime: %s\n", arg.Ts.String())
 	}
 
+	barg, bret, err := c.Bidirectional(context.Background())
+	if err != nil {
+		log.Fatalln(err)
+	}
+	for i := 0; i < 4; i++ {
+		err = barg.Write(hello.BidirectionalArg{Question: "What is the purpose of life?"})
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		answer, err := bret.Read()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		fmt.Printf("Answer: %s\n", answer.Answer)
+	}
+	barg.Close_()
+	bret.Close_()
+
+	time.Sleep(time.Minute)
 	wg.Wait()
 }

--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -100,7 +100,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 3; i++ {
 		err = barg.Write(hello.BidirectionalArg{Question: "What is the purpose of life?"})
 		if err != nil {
 			log.Fatalln(err)
@@ -116,6 +116,5 @@ func main() {
 	barg.Close_()
 	bret.Close_()
 
-	time.Sleep(time.Minute)
 	wg.Wait()
 }

--- a/examples/simple/hello/hello.orbit
+++ b/examples/simple/hello/hello.orbit
@@ -40,6 +40,15 @@ service {
             ts time `validate:"required"`
         }
     }
+
+    stream bidirectional {
+        arg: {
+            question string
+        }
+        ret: {
+            answer string
+        }
+    }
 }
 
 type info {

--- a/examples/simple/hello/hello_msgp_gen.go
+++ b/examples/simple/hello/hello_msgp_gen.go
@@ -7,6 +7,212 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *BidirectionalArg) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Question":
+			z.Question, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Question")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z BidirectionalArg) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Question"
+	err = en.Append(0x81, 0xa8, 0x51, 0x75, 0x65, 0x73, 0x74, 0x69, 0x6f, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Question)
+	if err != nil {
+		err = msgp.WrapError(err, "Question")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z BidirectionalArg) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Question"
+	o = append(o, 0x81, 0xa8, 0x51, 0x75, 0x65, 0x73, 0x74, 0x69, 0x6f, 0x6e)
+	o = msgp.AppendString(o, z.Question)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *BidirectionalArg) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Question":
+			z.Question, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Question")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z BidirectionalArg) Msgsize() (s int) {
+	s = 1 + 9 + msgp.StringPrefixSize + len(z.Question)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *BidirectionalRet) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Answer":
+			z.Answer, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Answer")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z BidirectionalRet) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Answer"
+	err = en.Append(0x81, 0xa6, 0x41, 0x6e, 0x73, 0x77, 0x65, 0x72)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Answer)
+	if err != nil {
+		err = msgp.WrapError(err, "Answer")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z BidirectionalRet) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Answer"
+	o = append(o, 0x81, 0xa6, 0x41, 0x6e, 0x73, 0x77, 0x65, 0x72)
+	o = msgp.AppendString(o, z.Answer)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *BidirectionalRet) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Answer":
+			z.Answer, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Answer")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z BidirectionalRet) Msgsize() (s int) {
+	s = 1 + 7 + msgp.StringPrefixSize + len(z.Answer)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *ClockTimeRet) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/examples/simple/hello/hello_msgp_gen_test.go
+++ b/examples/simple/hello/hello_msgp_gen_test.go
@@ -9,6 +9,232 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+func TestMarshalUnmarshalBidirectionalArg(t *testing.T) {
+	v := BidirectionalArg{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgBidirectionalArg(b *testing.B) {
+	v := BidirectionalArg{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgBidirectionalArg(b *testing.B) {
+	v := BidirectionalArg{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalBidirectionalArg(b *testing.B) {
+	v := BidirectionalArg{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeBidirectionalArg(t *testing.T) {
+	v := BidirectionalArg{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := BidirectionalArg{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeBidirectionalArg(b *testing.B) {
+	v := BidirectionalArg{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeBidirectionalArg(b *testing.B) {
+	v := BidirectionalArg{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalBidirectionalRet(t *testing.T) {
+	v := BidirectionalRet{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgBidirectionalRet(b *testing.B) {
+	v := BidirectionalRet{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgBidirectionalRet(b *testing.B) {
+	v := BidirectionalRet{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalBidirectionalRet(b *testing.B) {
+	v := BidirectionalRet{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeBidirectionalRet(t *testing.T) {
+	v := BidirectionalRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := BidirectionalRet{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeBidirectionalRet(b *testing.B) {
+	v := BidirectionalRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeBidirectionalRet(b *testing.B) {
+	v := BidirectionalRet{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalClockTimeRet(t *testing.T) {
 	v := ClockTimeRet{}
 	bts, err := v.MarshalMsg(nil)

--- a/examples/simple/hello/hello_orbit_gen.go
+++ b/examples/simple/hello/hello_orbit_gen.go
@@ -93,6 +93,14 @@ var validate = validator.New()
 //### Types ###//
 //#############//
 
+type BidirectionalArg struct {
+	Question string
+}
+
+type BidirectionalRet struct {
+	Answer string
+}
+
 type ClockTimeRet struct {
 	Ts time.Time `validate:"required"`
 }
@@ -124,27 +132,21 @@ type TestRet struct {
 
 //msgp:ignore InfoReadStream
 type InfoReadStream struct {
-	closer.Closer
 	stream  transport.Stream
 	codec   codec.Codec
 	maxSize int
 }
 
-func newInfoReadStream(cl closer.Closer, s transport.Stream, cc codec.Codec, ms int) *InfoReadStream {
-	return &InfoReadStream{Closer: cl, stream: s, codec: cc, maxSize: ms}
+func newInfoReadStream(s transport.Stream, cc codec.Codec, ms int) *InfoReadStream {
+	return &InfoReadStream{stream: s, codec: cc, maxSize: ms}
 }
 
 func (v1 *InfoReadStream) Read() (arg Info, err error) {
-	if v1.IsClosing() {
-		err = ErrClosed
-		return
-	}
 	err = packet.ReadDecode(v1.stream, &arg, v1.codec, v1.maxSize)
 	if err != nil {
 		if errors.Is(err, packet.ErrZeroData) || errors.Is(err, io.EOF) || v1.stream.IsClosed() {
 			err = ErrClosed
 		}
-		v1.Close_()
 		return
 	}
 	err = validate.Struct(arg)
@@ -164,18 +166,15 @@ type InfoWriteStream struct {
 }
 
 func newInfoWriteStream(cl closer.Closer, s transport.Stream, cc codec.Codec, ms int) *InfoWriteStream {
+	cl.OnClosing(s.Close)
 	cl.OnClosing(func() error { return packet.Write(s, nil, 0) })
 	return &InfoWriteStream{Closer: cl, stream: s, codec: cc, maxSize: ms}
 }
 
 func (v1 *InfoWriteStream) Write(ret Info) (err error) {
-	if v1.IsClosing() {
-		err = ErrClosed
-		return
-	}
 	err = packet.WriteEncode(v1.stream, &ret, v1.codec, v1.maxSize)
 	if err != nil {
-		if errors.Is(err, io.EOF) || v1.stream.IsClosed() {
+		if errors.Is(err, io.EOF) || v1.IsClosing() || v1.stream.IsClosed() {
 			v1.Close_()
 			return ErrClosed
 		}
@@ -192,17 +191,14 @@ type ClockTimeRetReadStream struct {
 }
 
 func newClockTimeRetReadStream(cl closer.Closer, s transport.Stream, cc codec.Codec, ms int) *ClockTimeRetReadStream {
+	cl.OnClosing(s.Close)
 	return &ClockTimeRetReadStream{Closer: cl, stream: s, codec: cc, maxSize: ms}
 }
 
 func (v1 *ClockTimeRetReadStream) Read() (arg ClockTimeRet, err error) {
-	if v1.IsClosing() {
-		err = ErrClosed
-		return
-	}
 	err = packet.ReadDecode(v1.stream, &arg, v1.codec, v1.maxSize)
 	if err != nil {
-		if errors.Is(err, packet.ErrZeroData) || errors.Is(err, io.EOF) || v1.stream.IsClosed() {
+		if errors.Is(err, packet.ErrZeroData) || errors.Is(err, io.EOF) || v1.IsClosing() || v1.stream.IsClosed() {
 			err = ErrClosed
 		}
 		v1.Close_()
@@ -218,26 +214,122 @@ func (v1 *ClockTimeRetReadStream) Read() (arg ClockTimeRet, err error) {
 
 //msgp:ignore ClockTimeRetWriteStream
 type ClockTimeRetWriteStream struct {
+	stream  transport.Stream
+	codec   codec.Codec
+	maxSize int
+}
+
+func newClockTimeRetWriteStream(s transport.Stream, cc codec.Codec, ms int) *ClockTimeRetWriteStream {
+	return &ClockTimeRetWriteStream{stream: s, codec: cc, maxSize: ms}
+}
+
+func (v1 *ClockTimeRetWriteStream) Write(ret ClockTimeRet) (err error) {
+	err = packet.WriteEncode(v1.stream, &ret, v1.codec, v1.maxSize)
+	if err != nil {
+		if errors.Is(err, io.EOF) || v1.stream.IsClosed() {
+			return ErrClosed
+		}
+	}
+	return
+}
+
+//msgp:ignore BidirectionalArgReadStream
+type BidirectionalArgReadStream struct {
+	stream  transport.Stream
+	codec   codec.Codec
+	maxSize int
+}
+
+func newBidirectionalArgReadStream(s transport.Stream, cc codec.Codec, ms int) *BidirectionalArgReadStream {
+	return &BidirectionalArgReadStream{stream: s, codec: cc, maxSize: ms}
+}
+
+func (v1 *BidirectionalArgReadStream) Read() (arg BidirectionalArg, err error) {
+	err = packet.ReadDecode(v1.stream, &arg, v1.codec, v1.maxSize)
+	if err != nil {
+		if errors.Is(err, packet.ErrZeroData) || errors.Is(err, io.EOF) || v1.stream.IsClosed() {
+			err = ErrClosed
+		}
+		return
+	}
+	err = validate.Struct(arg)
+	if err != nil {
+		err = _valErrCheck(err)
+		return
+	}
+	return
+}
+
+//msgp:ignore BidirectionalArgWriteStream
+type BidirectionalArgWriteStream struct {
 	closer.Closer
 	stream  transport.Stream
 	codec   codec.Codec
 	maxSize int
 }
 
-func newClockTimeRetWriteStream(cl closer.Closer, s transport.Stream, cc codec.Codec, ms int) *ClockTimeRetWriteStream {
+func newBidirectionalArgWriteStream(cl closer.Closer, s transport.Stream, cc codec.Codec, ms int) *BidirectionalArgWriteStream {
+	cl.OnClosing(s.Close)
 	cl.OnClosing(func() error { return packet.Write(s, nil, 0) })
-	return &ClockTimeRetWriteStream{Closer: cl, stream: s, codec: cc, maxSize: ms}
+	return &BidirectionalArgWriteStream{Closer: cl, stream: s, codec: cc, maxSize: ms}
 }
 
-func (v1 *ClockTimeRetWriteStream) Write(ret ClockTimeRet) (err error) {
-	if v1.IsClosing() {
-		err = ErrClosed
+func (v1 *BidirectionalArgWriteStream) Write(ret BidirectionalArg) (err error) {
+	err = packet.WriteEncode(v1.stream, &ret, v1.codec, v1.maxSize)
+	if err != nil {
+		if errors.Is(err, io.EOF) || v1.IsClosing() || v1.stream.IsClosed() {
+			v1.Close_()
+			return ErrClosed
+		}
+	}
+	return
+}
+
+//msgp:ignore BidirectionalRetReadStream
+type BidirectionalRetReadStream struct {
+	closer.Closer
+	stream  transport.Stream
+	codec   codec.Codec
+	maxSize int
+}
+
+func newBidirectionalRetReadStream(cl closer.Closer, s transport.Stream, cc codec.Codec, ms int) *BidirectionalRetReadStream {
+	cl.OnClosing(s.Close)
+	return &BidirectionalRetReadStream{Closer: cl, stream: s, codec: cc, maxSize: ms}
+}
+
+func (v1 *BidirectionalRetReadStream) Read() (arg BidirectionalRet, err error) {
+	err = packet.ReadDecode(v1.stream, &arg, v1.codec, v1.maxSize)
+	if err != nil {
+		if errors.Is(err, packet.ErrZeroData) || errors.Is(err, io.EOF) || v1.IsClosing() || v1.stream.IsClosed() {
+			err = ErrClosed
+		}
+		v1.Close_()
 		return
 	}
+	err = validate.Struct(arg)
+	if err != nil {
+		err = _valErrCheck(err)
+		return
+	}
+	return
+}
+
+//msgp:ignore BidirectionalRetWriteStream
+type BidirectionalRetWriteStream struct {
+	stream  transport.Stream
+	codec   codec.Codec
+	maxSize int
+}
+
+func newBidirectionalRetWriteStream(s transport.Stream, cc codec.Codec, ms int) *BidirectionalRetWriteStream {
+	return &BidirectionalRetWriteStream{stream: s, codec: cc, maxSize: ms}
+}
+
+func (v1 *BidirectionalRetWriteStream) Write(ret BidirectionalRet) (err error) {
 	err = packet.WriteEncode(v1.stream, &ret, v1.codec, v1.maxSize)
 	if err != nil {
 		if errors.Is(err, io.EOF) || v1.stream.IsClosed() {
-			v1.Close_()
 			return ErrClosed
 		}
 	}
@@ -264,9 +356,10 @@ const (
 	SayHi = "SayHi"
 	Test  = "Test"
 	// StreamIDs
-	Lul        = "Lul"
-	TimeStream = "TimeStream"
-	ClockTime  = "ClockTime"
+	Lul           = "Lul"
+	TimeStream    = "TimeStream"
+	ClockTime     = "ClockTime"
+	Bidirectional = "Bidirectional"
 )
 
 type Client interface {
@@ -278,6 +371,7 @@ type Client interface {
 	Lul(ctx context.Context) (stream transport.Stream, err error)
 	TimeStream(ctx context.Context) (arg *InfoWriteStream, err error)
 	ClockTime(ctx context.Context) (ret *ClockTimeRetReadStream, err error)
+	Bidirectional(ctx context.Context) (arg *BidirectionalArgWriteStream, ret *BidirectionalRetReadStream, err error)
 }
 
 type Service interface {
@@ -293,6 +387,7 @@ type ServiceHandler interface {
 	Lul(ctx oservice.Context, stream transport.Stream)
 	TimeStream(ctx oservice.Context, arg *InfoReadStream)
 	ClockTime(ctx oservice.Context, ret *ClockTimeRetWriteStream)
+	Bidirectional(ctx oservice.Context, arg *BidirectionalArgReadStream, ret *BidirectionalRetWriteStream)
 }
 
 type client struct {
@@ -372,7 +467,6 @@ func (v1 *client) TimeStream(ctx context.Context) (arg *InfoWriteStream, err err
 		return
 	}
 	arg = newInfoWriteStream(v1.CloserOneWay(), stream, v1.codec, v1.maxArgSize)
-	arg.OnClosing(stream.Close)
 	return
 }
 
@@ -387,7 +481,21 @@ func (v1 *client) ClockTime(ctx context.Context) (ret *ClockTimeRetReadStream, e
 		return
 	}
 	ret = newClockTimeRetReadStream(v1.CloserOneWay(), stream, v1.codec, v1.maxRetSize)
-	ret.OnClosing(stream.Close)
+	return
+}
+
+func (v1 *client) Bidirectional(ctx context.Context) (arg *BidirectionalArgWriteStream, ret *BidirectionalRetReadStream, err error) {
+	if v1.streamInitTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, v1.streamInitTimeout)
+		defer cancel()
+	}
+	stream, err := v1.Stream(ctx, Bidirectional)
+	if err != nil {
+		return
+	}
+	arg = newBidirectionalArgWriteStream(v1.CloserOneWay(), stream, v1.codec, v1.maxArgSize)
+	ret = newBidirectionalRetReadStream(v1.CloserOneWay(), stream, v1.codec, v1.maxRetSize)
 	return
 }
 
@@ -412,6 +520,7 @@ func NewService(h ServiceHandler, opts *oservice.Options) (s Service, err error)
 	os.RegisterStream(Lul, srvc.lul)
 	os.RegisterStream(TimeStream, srvc.timeStream)
 	os.RegisterStream(ClockTime, srvc.clockTime)
+	os.RegisterStream(Bidirectional, srvc.bidirectional)
 	s = os
 	return
 }
@@ -460,13 +569,22 @@ func (v1 *service) lul(ctx oservice.Context, stream transport.Stream) {
 	v1.h.Lul(ctx, stream)
 }
 func (v1 *service) timeStream(ctx oservice.Context, stream transport.Stream) {
-	arg := newInfoReadStream(v1.CloserOneWay(), stream, v1.codec, v1.maxArgSize)
-	arg.OnClosing(stream.Close)
+	defer stream.Close()
+	arg := newInfoReadStream(stream, v1.codec, v1.maxArgSize)
 	v1.h.TimeStream(ctx, arg)
 }
 
 func (v1 *service) clockTime(ctx oservice.Context, stream transport.Stream) {
-	ret := newClockTimeRetWriteStream(v1.CloserOneWay(), stream, v1.codec, v1.maxRetSize)
-	ret.OnClosing(stream.Close)
+	defer stream.Close()
+	ret := newClockTimeRetWriteStream(stream, v1.codec, v1.maxRetSize)
+	defer func() { _ = packet.Write(stream, nil, 0) }()
 	v1.h.ClockTime(ctx, ret)
+}
+
+func (v1 *service) bidirectional(ctx oservice.Context, stream transport.Stream) {
+	defer stream.Close()
+	arg := newBidirectionalArgReadStream(stream, v1.codec, v1.maxArgSize)
+	ret := newBidirectionalRetWriteStream(stream, v1.codec, v1.maxRetSize)
+	defer func() { _ = packet.Write(stream, nil, 0) }()
+	v1.h.Bidirectional(ctx, arg, ret)
 }

--- a/examples/simple/service/main.go
+++ b/examples/simple/service/main.go
@@ -128,3 +128,21 @@ func (s *ServiceHandler) Lul(ctx service.Context, stream transport.Stream) {
 func (s *ServiceHandler) TimeStream(ctx service.Context, arg *hello.InfoReadStream) {
 	panic("implement me")
 }
+
+func (s *ServiceHandler) Bidirectional(ctx service.Context, arg *hello.BidirectionalArgReadStream, ret *hello.BidirectionalRetWriteStream) {
+	for i := 0; i < 3; i++ {
+		a, err := arg.Read()
+		if err != nil {
+			fmt.Printf("ERROR handler.Bidirectional read: %v\n", err)
+			return
+		}
+
+		fmt.Printf("Question: %s?\n", a.Question)
+
+		err = ret.Write(hello.BidirectionalRet{Answer: "42"})
+		if err != nil {
+			fmt.Printf("ERROR handler.Bidirectional write: %v\n", err)
+			return
+		}
+	}
+}

--- a/internal/codegen/gen/gen_service_stream.go
+++ b/internal/codegen/gen/gen_service_stream.go
@@ -73,31 +73,12 @@ func (g *generator) genServiceClientStream(s *ast.Stream, errs []*ast.Error) {
 		g.writef("arg = new%sWriteStream(%s.CloserOneWay(), stream, %s.codec,", s.Arg.Name(), recv, recv)
 		g.writePacketMaxSizeParam(s.MaxArgSize, fmt.Sprintf("%s.maxArgSize", recv))
 		g.writeLn(")")
-
-		// Close unidirectional stream immediately.
-		if s.Ret == nil {
-			g.writeLn("arg.OnClosing(stream.Close)")
-		}
 	}
 
 	if s.Ret != nil {
 		g.writef("ret = new%sReadStream(%s.CloserOneWay(), stream, %s.codec,", s.Ret.Name(), recv, recv)
 		g.writePacketMaxSizeParam(s.MaxRetSize, fmt.Sprintf("%s.maxRetSize", recv))
 		g.writeLn(")")
-
-		// Close unidirectional stream immediately.
-		if s.Arg == nil {
-			g.writeLn("ret.OnClosing(stream.Close)")
-		}
-	}
-
-	// For a bidirectional stream, we need a new goroutine.
-	if s.Arg != nil && s.Ret != nil {
-		g.writeLn("go func() {")
-		g.writeLn("<-arg.ClosedChan()")
-		g.writeLn("<-ret.ClosedChan()")
-		g.writeLn("_ = stream.Close()")
-		g.writeLn("}()")
 	}
 
 	g.writeLn("return")
@@ -128,37 +109,24 @@ func (g *generator) genServiceHandlerStream(s *ast.Stream, errs []*ast.Error) {
 		return
 	}
 
+	// We have an orbit-managed stream now.
+	// Close the stream, as soon as the handler is done.
+	g.writeLn("defer stream.Close()")
+
 	handlerArgs := "ctx,"
 	if s.Arg != nil {
 		handlerArgs += "arg,"
-		g.writef("arg := new%sReadStream(%s.CloserOneWay(), stream, %s.codec,", s.Arg.Name(), recv, recv)
+		g.writef("arg := new%sReadStream(stream, %s.codec,", s.Arg.Name(), recv)
 		g.writePacketMaxSizeParam(s.MaxArgSize, fmt.Sprintf("%s.maxArgSize", recv))
 		g.writeLn(")")
-
-		// Close unidirectional stream immediately.
-		if s.Ret == nil {
-			g.writeLn("arg.OnClosing(stream.Close)")
-		}
 	}
 	if s.Ret != nil {
 		handlerArgs += "ret,"
-		g.writef("ret := new%sWriteStream(%s.CloserOneWay(), stream, %s.codec,", s.Ret.Name(), recv, recv)
+		g.writef("ret := new%sWriteStream(stream, %s.codec,", s.Ret.Name(), recv)
 		g.writePacketMaxSizeParam(s.MaxRetSize, fmt.Sprintf("%s.maxRetSize", recv))
 		g.writeLn(")")
-
-		// Close unidirectional stream immediately.
-		if s.Arg == nil {
-			g.writeLn("ret.OnClosing(stream.Close)")
-		}
-	}
-
-	// For a bidirectional stream, we need a new goroutine.
-	if s.Arg != nil && s.Ret != nil {
-		g.writeLn("go func() {")
-		g.writeLn("<-arg.ClosedChan()")
-		g.writeLn("<-ret.ClosedChan()")
-		g.writeLn("_ = stream.Close()")
-		g.writeLn("}()")
+		// Ensure, the zero package is sent to the other side.
+		g.writeLn("defer func() { _ = packet.Write(stream, nil, 0) }()")
 	}
 
 	g.writefLn("%s.h.%s(%s)", recv, s.Name, handlerArgs)

--- a/internal/codegen/gen/gen_service_stream.go
+++ b/internal/codegen/gen/gen_service_stream.go
@@ -126,6 +126,8 @@ func (g *generator) genServiceHandlerStream(s *ast.Stream, errs []*ast.Error) {
 		g.writePacketMaxSizeParam(s.MaxRetSize, fmt.Sprintf("%s.maxRetSize", recv))
 		g.writeLn(")")
 		// Ensure, the zero package is sent to the other side.
+		g.writeLn("// Service has a write stream, therefore, ensure to send the zero packet")
+		g.writeLn("// once the handler is done to inform the remote reader side of the writer-close.")
 		g.writeLn("defer func() { _ = packet.Write(stream, nil, 0) }()")
 	}
 

--- a/internal/codegen/version.go
+++ b/internal/codegen/version.go
@@ -40,5 +40,5 @@ const (
 	// codegen has been improved, but no backwards incompatible changes
 	// have been introduced. May be used to invalidate the build cache
 	// of the codegen, so that a project definitely uses its new features.
-	CacheVersion = 3
+	CacheVersion = 4
 )


### PR DESCRIPTION
closes #54  
An additional change not mentioned in the issue:  
- Due to the change we are planning in #56 we decided to limit the scope of arg/ret-stream structs on the **service side** to only the handler func. This means, as soon as the service handler func returns, the stream is automatically closed. Therefore, it is no longer needed to have a separate closer in the service-related arg/ret-stream structs.  