### PR TITLE
F78 client connection state

### DIFF
--- a/examples/simple/hello/hello_msgp_gen_test.go
+++ b/examples/simple/hello/hello_msgp_gen_test.go
@@ -74,7 +74,7 @@ func TestEncodeDecodeBidirectionalArg(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeBidirectionalArg Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := BidirectionalArg{}
@@ -187,7 +187,7 @@ func TestEncodeDecodeBidirectionalRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeBidirectionalRet Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := BidirectionalRet{}
@@ -300,7 +300,7 @@ func TestEncodeDecodeClockTimeRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeClockTimeRet Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := ClockTimeRet{}
@@ -413,7 +413,7 @@ func TestEncodeDecodeInfo(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeInfo Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := Info{}
@@ -526,7 +526,7 @@ func TestEncodeDecodeSayHiArg(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeSayHiArg Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := SayHiArg{}
@@ -639,7 +639,7 @@ func TestEncodeDecodeSayHiRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeSayHiRet Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := SayHiRet{}
@@ -752,7 +752,7 @@ func TestEncodeDecodeTestArg(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeTestArg Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := TestArg{}
@@ -865,7 +865,7 @@ func TestEncodeDecodeTestRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeTestRet Msgsize() is inaccurate")
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
 	vn := TestRet{}

--- a/examples/simple/hello/hello_msgp_gen_test.go
+++ b/examples/simple/hello/hello_msgp_gen_test.go
@@ -74,7 +74,7 @@ func TestEncodeDecodeBidirectionalArg(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeBidirectionalArg Msgsize() is inaccurate")
 	}
 
 	vn := BidirectionalArg{}
@@ -187,7 +187,7 @@ func TestEncodeDecodeBidirectionalRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeBidirectionalRet Msgsize() is inaccurate")
 	}
 
 	vn := BidirectionalRet{}
@@ -300,7 +300,7 @@ func TestEncodeDecodeClockTimeRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeClockTimeRet Msgsize() is inaccurate")
 	}
 
 	vn := ClockTimeRet{}
@@ -413,7 +413,7 @@ func TestEncodeDecodeInfo(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeInfo Msgsize() is inaccurate")
 	}
 
 	vn := Info{}
@@ -526,7 +526,7 @@ func TestEncodeDecodeSayHiArg(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeSayHiArg Msgsize() is inaccurate")
 	}
 
 	vn := SayHiArg{}
@@ -639,7 +639,7 @@ func TestEncodeDecodeSayHiRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeSayHiRet Msgsize() is inaccurate")
 	}
 
 	vn := SayHiRet{}
@@ -752,7 +752,7 @@ func TestEncodeDecodeTestArg(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeTestArg Msgsize() is inaccurate")
 	}
 
 	vn := TestArg{}
@@ -865,7 +865,7 @@ func TestEncodeDecodeTestRet(t *testing.T) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecodeTestRet Msgsize() is inaccurate")
 	}
 
 	vn := TestRet{}

--- a/examples/simple/hello/hello_orbit_gen.go
+++ b/examples/simple/hello/hello_orbit_gen.go
@@ -334,6 +334,7 @@ const (
 
 type Client interface {
 	closer.Closer
+	StateChan() <-chan oclient.State
 	// Calls
 	SayHi(ctx context.Context, arg SayHiArg) (ret SayHiRet, err error)
 	Test(ctx context.Context, arg TestArg) (ret TestRet, err error)
@@ -376,6 +377,10 @@ func NewClient(opts *oclient.Options) (c Client, err error) {
 	}
 	c = &client{Client: oc, codec: opts.Codec, callTimeout: opts.CallTimeout, streamInitTimeout: opts.StreamInitTimeout, maxArgSize: opts.MaxArgSize, maxRetSize: opts.MaxRetSize}
 	return
+}
+
+func (v1 *client) StateChan() <-chan oclient.State {
+	return v1.StateChan()
 }
 
 func (v1 *client) SayHi(ctx context.Context, arg SayHiArg) (ret SayHiRet, err error) {

--- a/examples/simple/hello/hello_orbit_gen.go
+++ b/examples/simple/hello/hello_orbit_gen.go
@@ -380,7 +380,7 @@ func NewClient(opts *oclient.Options) (c Client, err error) {
 }
 
 func (v1 *client) StateChan() <-chan oclient.State {
-	return v1.StateChan()
+	return v1.Client.StateChan()
 }
 
 func (v1 *client) SayHi(ctx context.Context, arg SayHiArg) (ret SayHiRet, err error) {

--- a/examples/simple/hello/hello_orbit_gen.go
+++ b/examples/simple/hello/hello_orbit_gen.go
@@ -166,7 +166,7 @@ func (v1 *TimeStreamServiceStream) Read() (arg Info, err error) {
 	err = v1.stream.Read(&arg)
 	if err != nil {
 		err = _serviceErrorCheck(err)
-		if errors.Is(err, oclient.ErrClosed) {
+		if errors.Is(err, oservice.ErrClosed) {
 			err = ErrClosed
 		}
 		return
@@ -220,7 +220,7 @@ func (v1 *ClockTimeServiceStream) Write(ret ClockTimeRet) (err error) {
 	err = v1.stream.Write(ret)
 	if err != nil {
 		err = _serviceErrorCheck(err)
-		if errors.Is(err, oclient.ErrClosed) {
+		if errors.Is(err, oservice.ErrClosed) {
 			err = ErrClosed
 		}
 		return
@@ -281,7 +281,7 @@ func (v1 *BidirectionalServiceStream) Read() (arg BidirectionalArg, err error) {
 	err = v1.stream.Read(&arg)
 	if err != nil {
 		err = _serviceErrorCheck(err)
-		if errors.Is(err, oclient.ErrClosed) {
+		if errors.Is(err, oservice.ErrClosed) {
 			err = ErrClosed
 		}
 		return
@@ -298,7 +298,7 @@ func (v1 *BidirectionalServiceStream) Write(ret BidirectionalRet) (err error) {
 	err = v1.stream.Write(ret)
 	if err != nil {
 		err = _serviceErrorCheck(err)
-		if errors.Is(err, oclient.ErrClosed) {
+		if errors.Is(err, oservice.ErrClosed) {
 			err = ErrClosed
 		}
 		return

--- a/internal/codegen/gen/gen_service.go
+++ b/internal/codegen/gen/gen_service.go
@@ -134,7 +134,7 @@ func (g *generator) genClientStruct(calls []*ast.Call, streams []*ast.Stream, er
 
 	// Generate the state chan forwarding.
 	g.writefLn("func (%s *client) StateChan() <-chan oclient.State {", recv)
-	g.writefLn("return %s.StateChan()", recv)
+	g.writefLn("return %s.Client.StateChan()", recv)
 	g.writeLn("}")
 	g.writeLn("")
 

--- a/internal/codegen/gen/gen_service.go
+++ b/internal/codegen/gen/gen_service.go
@@ -58,6 +58,7 @@ func (g *generator) genService(srvc *ast.Service, errs []*ast.Error) {
 func (g *generator) genClientInterface(calls []*ast.Call, streams []*ast.Stream) {
 	g.writeLn("type Client interface {")
 	g.writeLn("closer.Closer")
+	g.writeLn("StateChan() <-chan oclient.State")
 
 	if len(calls) > 0 {
 		g.writeLn("// Calls")
@@ -128,6 +129,12 @@ func (g *generator) genClientStruct(calls []*ast.Call, streams []*ast.Stream, er
 	g.writeLn("c = &client{Client: oc, codec: opts.Codec, callTimeout: opts.CallTimeout, streamInitTimeout: opts.StreamInitTimeout, " +
 		"maxArgSize: opts.MaxArgSize, maxRetSize:opts.MaxRetSize}")
 	g.writeLn("return")
+	g.writeLn("}")
+	g.writeLn("")
+
+	// Generate the state chan forwarding.
+	g.writefLn("func (%s *client) StateChan() <-chan oclient.State {", recv)
+	g.writefLn("return %s.StateChan()", recv)
 	g.writeLn("}")
 	g.writeLn("")
 

--- a/internal/codegen/version.go
+++ b/internal/codegen/version.go
@@ -40,5 +40,5 @@ const (
 	// codegen has been improved, but no backwards incompatible changes
 	// have been introduced. May be used to invalidate the build cache
 	// of the codegen, so that a project definitely uses its new features.
-	CacheVersion = 7
+	CacheVersion = 8
 )

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,8 +42,21 @@ const (
 	DefaultMaxSize = -2
 )
 
+type State int
+
+const (
+	StateConnected    State = 0
+	StateReconnecting State = 1
+	StateDisconnected State = 2
+)
+
 type Client interface {
 	closer.Closer
+
+	// StateChan returns a read-only channel that can be listened on
+	// to get notifications about changes of the client's state.
+	// This allows to react for example to sudden disconnects.
+	StateChan() <-chan State
 
 	// Call performs a call on the shared main stream.
 	// Returns ErrConnect if a session connection attempt failed.


### PR DESCRIPTION
Add `StateChan()` method to the orbit Client, which allows to receive signals about the connection state of the client.

closes #78 