### PR TITLE
declare errors per call/stream

### DIFF
--- a/examples/full/api/api.orbit
+++ b/examples/full/api/api.orbit
@@ -10,6 +10,7 @@ errors {
     authFailed = 1
     notFound = 2
     nameAlreadyExists = 3
+    emailAlreadyExists = 4
 }
 
 service {
@@ -18,6 +19,7 @@ service {
             email string `validate:"email"` // Automatic email validation by go-playground/validator
             password string `validate:"required,min=8"`
         }
+        errors: emailAlreadyExists
     }
 
     call login {
@@ -25,6 +27,7 @@ service {
             user string `validate:"required"`
             password string `validate:"required"`
         }
+        errors: authFailed
     }
 
     // No parameters needed.
@@ -41,12 +44,14 @@ service {
     call getUser {
         arg: { userID string `validate:"required"` }
         ret: UserDetail
+        errors: notFound
     }
 
     call getUserProfileImage {
         async // Prevents head-of-line blocking, since a separate stream is opened for each call.
         arg: { userID string `validate:"required"` }
         ret: { jpeg []byte }
+        errors: notFound
     }
 
     call createUser {
@@ -57,6 +62,7 @@ service {
             email string `validate:"email"`
         }
         ret: UserDetail
+        errors: nameAlreadyExists
     }
 
     call updateUser {
@@ -68,6 +74,7 @@ service {
             status string
             email string  `validate:"email"`
         }
+        errors: nameAlreadyExists, notFound
     }
 
     call updateUserProfileImage {
@@ -78,6 +85,7 @@ service {
         }
         maxArgSize: 5MB
         timeout: 60s
+        errors: notFound
     }
 
     // A stream can be left open to asynchronously push new data from the server
@@ -85,6 +93,7 @@ service {
     stream observeNotifications {
         arg: { userID string `validate:"required"` }
         ret: Notification
+        errors: notFound
     }
 }
 

--- a/examples/full/api/api_orbit_gen.go
+++ b/examples/full/api/api_orbit_gen.go
@@ -45,15 +45,17 @@ var (
 var ErrClosed = errors.New("closed")
 
 const (
-	ErrCodeAuthFailed        = 1
-	ErrCodeNameAlreadyExists = 3
-	ErrCodeNotFound          = 2
+	ErrCodeAuthFailed         = 1
+	ErrCodeEmailAlreadyExists = 4
+	ErrCodeNameAlreadyExists  = 3
+	ErrCodeNotFound           = 2
 )
 
 var (
-	ErrAuthFailed        = errors.New("auth failed")
-	ErrNameAlreadyExists = errors.New("name already exists")
-	ErrNotFound          = errors.New("not found")
+	ErrAuthFailed         = errors.New("auth failed")
+	ErrEmailAlreadyExists = errors.New("email already exists")
+	ErrNameAlreadyExists  = errors.New("name already exists")
+	ErrNotFound           = errors.New("not found")
 )
 
 func _clientErrorCheck(err error) error {
@@ -62,6 +64,8 @@ func _clientErrorCheck(err error) error {
 		switch cErr.Code() {
 		case ErrCodeAuthFailed:
 			return ErrAuthFailed
+		case ErrCodeEmailAlreadyExists:
+			return ErrEmailAlreadyExists
 		case ErrCodeNameAlreadyExists:
 			return ErrNameAlreadyExists
 		case ErrCodeNotFound:
@@ -74,6 +78,8 @@ func _clientErrorCheck(err error) error {
 func _serviceErrorCheck(err error) error {
 	if errors.Is(err, ErrAuthFailed) {
 		return oservice.NewError(err, ErrAuthFailed.Error(), ErrCodeAuthFailed)
+	} else if errors.Is(err, ErrEmailAlreadyExists) {
+		return oservice.NewError(err, ErrEmailAlreadyExists.Error(), ErrCodeEmailAlreadyExists)
 	} else if errors.Is(err, ErrNameAlreadyExists) {
 		return oservice.NewError(err, ErrNameAlreadyExists.Error(), ErrCodeNameAlreadyExists)
 	} else if errors.Is(err, ErrNotFound) {
@@ -194,9 +200,16 @@ func newObserveNotificationsClientStream(s oclient.TypedRWStream) *ObserveNotifi
 func (v1 *ObserveNotificationsClientStream) Read() (ret Notification, err error) {
 	err = v1.stream.Read(&ret)
 	if err != nil {
-		err = _clientErrorCheck(err)
 		if errors.Is(err, oclient.ErrClosed) {
 			err = ErrClosed
+			return
+		}
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeNotFound:
+				err = ErrNotFound
+			}
 		}
 		return
 	}
@@ -211,9 +224,16 @@ func (v1 *ObserveNotificationsClientStream) Read() (ret Notification, err error)
 func (v1 *ObserveNotificationsClientStream) Write(arg ObserveNotificationsArg) (err error) {
 	err = v1.stream.Write(arg)
 	if err != nil {
-		err = _clientErrorCheck(err)
 		if errors.Is(err, oclient.ErrClosed) {
 			err = ErrClosed
+			return
+		}
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeNotFound:
+				err = ErrNotFound
+			}
 		}
 		return
 	}
@@ -233,9 +253,12 @@ func newObserveNotificationsServiceStream(s oservice.TypedRWStream) *ObserveNoti
 func (v1 *ObserveNotificationsServiceStream) Read() (arg ObserveNotificationsArg, err error) {
 	err = v1.stream.Read(&arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
 		if errors.Is(err, oservice.ErrClosed) {
 			err = ErrClosed
+			return
+		}
+		if errors.Is(err, ErrNotFound) {
+			err = oservice.NewError(err, ErrNotFound.Error(), ErrCodeNotFound)
 		}
 		return
 	}
@@ -250,9 +273,12 @@ func (v1 *ObserveNotificationsServiceStream) Read() (arg ObserveNotificationsArg
 func (v1 *ObserveNotificationsServiceStream) Write(ret Notification) (err error) {
 	err = v1.stream.Write(ret)
 	if err != nil {
-		err = _serviceErrorCheck(err)
 		if errors.Is(err, oservice.ErrClosed) {
 			err = ErrClosed
+			return
+		}
+		if errors.Is(err, ErrNotFound) {
+			err = oservice.NewError(err, ErrNotFound.Error(), ErrCodeNotFound)
 		}
 		return
 	}
@@ -355,7 +381,13 @@ func (v1 *client) Register(ctx context.Context, arg RegisterArg) (err error) {
 	}
 	err = v1.Call(ctx, CallIDRegister, arg, nil)
 	if err != nil {
-		err = _clientErrorCheck(err)
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeEmailAlreadyExists:
+				err = ErrEmailAlreadyExists
+			}
+		}
 		return
 	}
 	return
@@ -369,7 +401,13 @@ func (v1 *client) Login(ctx context.Context, arg LoginArg) (err error) {
 	}
 	err = v1.Call(ctx, CallIDLogin, arg, nil)
 	if err != nil {
-		err = _clientErrorCheck(err)
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeAuthFailed:
+				err = ErrAuthFailed
+			}
+		}
 		return
 	}
 	return
@@ -416,7 +454,13 @@ func (v1 *client) GetUser(ctx context.Context, arg GetUserArg) (ret UserDetail, 
 	}
 	err = v1.Call(ctx, CallIDGetUser, arg, &ret)
 	if err != nil {
-		err = _clientErrorCheck(err)
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeNotFound:
+				err = ErrNotFound
+			}
+		}
 		return
 	}
 	err = validate.Struct(ret)
@@ -435,7 +479,13 @@ func (v1 *client) GetUserProfileImage(ctx context.Context, arg GetUserProfileIma
 	}
 	err = v1.AsyncCall(ctx, CallIDGetUserProfileImage, arg, &ret, oclient.DefaultMaxSize, oclient.DefaultMaxSize)
 	if err != nil {
-		err = _clientErrorCheck(err)
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeNotFound:
+				err = ErrNotFound
+			}
+		}
 		return
 	}
 	err = validate.Struct(ret)
@@ -454,7 +504,13 @@ func (v1 *client) CreateUser(ctx context.Context, arg CreateUserArg) (ret UserDe
 	}
 	err = v1.Call(ctx, CallIDCreateUser, arg, &ret)
 	if err != nil {
-		err = _clientErrorCheck(err)
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeNameAlreadyExists:
+				err = ErrNameAlreadyExists
+			}
+		}
 		return
 	}
 	err = validate.Struct(ret)
@@ -473,7 +529,15 @@ func (v1 *client) UpdateUser(ctx context.Context, arg UpdateUserArg) (err error)
 	}
 	err = v1.Call(ctx, CallIDUpdateUser, arg, nil)
 	if err != nil {
-		err = _clientErrorCheck(err)
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeNameAlreadyExists:
+				err = ErrNameAlreadyExists
+			case ErrCodeNotFound:
+				err = ErrNotFound
+			}
+		}
 		return
 	}
 	return
@@ -484,7 +548,13 @@ func (v1 *client) UpdateUserProfileImage(ctx context.Context, arg UpdateUserProf
 	defer cancel()
 	err = v1.AsyncCall(ctx, CallIDUpdateUserProfileImage, arg, nil, 5242880, 0)
 	if err != nil {
-		err = _clientErrorCheck(err)
+		var cErr oclient.Error
+		if errors.As(err, &cErr) {
+			switch cErr.Code() {
+			case ErrCodeNotFound:
+				err = ErrNotFound
+			}
+		}
 		return
 	}
 	return
@@ -547,7 +617,9 @@ func (v1 *service) register(ctx oservice.Context, argData []byte) (retData inter
 	}
 	err = v1.h.Register(ctx, arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
+		if errors.Is(err, ErrEmailAlreadyExists) {
+			err = oservice.NewError(err, ErrEmailAlreadyExists.Error(), ErrCodeEmailAlreadyExists)
+		}
 		return
 	}
 	return
@@ -566,7 +638,9 @@ func (v1 *service) login(ctx oservice.Context, argData []byte) (retData interfac
 	}
 	err = v1.h.Login(ctx, arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
+		if errors.Is(err, ErrAuthFailed) {
+			err = oservice.NewError(err, ErrAuthFailed.Error(), ErrCodeAuthFailed)
+		}
 		return
 	}
 	return
@@ -614,7 +688,9 @@ func (v1 *service) getUser(ctx oservice.Context, argData []byte) (retData interf
 	}
 	ret, err := v1.h.GetUser(ctx, arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
+		if errors.Is(err, ErrNotFound) {
+			err = oservice.NewError(err, ErrNotFound.Error(), ErrCodeNotFound)
+		}
 		return
 	}
 	retData = &ret
@@ -634,7 +710,9 @@ func (v1 *service) getUserProfileImage(ctx oservice.Context, argData []byte) (re
 	}
 	ret, err := v1.h.GetUserProfileImage(ctx, arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
+		if errors.Is(err, ErrNotFound) {
+			err = oservice.NewError(err, ErrNotFound.Error(), ErrCodeNotFound)
+		}
 		return
 	}
 	retData = &ret
@@ -654,7 +732,9 @@ func (v1 *service) createUser(ctx oservice.Context, argData []byte) (retData int
 	}
 	ret, err := v1.h.CreateUser(ctx, arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
+		if errors.Is(err, ErrNameAlreadyExists) {
+			err = oservice.NewError(err, ErrNameAlreadyExists.Error(), ErrCodeNameAlreadyExists)
+		}
 		return
 	}
 	retData = &ret
@@ -674,7 +754,11 @@ func (v1 *service) updateUser(ctx oservice.Context, argData []byte) (retData int
 	}
 	err = v1.h.UpdateUser(ctx, arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
+		if errors.Is(err, ErrNameAlreadyExists) {
+			err = oservice.NewError(err, ErrNameAlreadyExists.Error(), ErrCodeNameAlreadyExists)
+		} else if errors.Is(err, ErrNotFound) {
+			err = oservice.NewError(err, ErrNotFound.Error(), ErrCodeNotFound)
+		}
 		return
 	}
 	return
@@ -693,7 +777,9 @@ func (v1 *service) updateUserProfileImage(ctx oservice.Context, argData []byte) 
 	}
 	err = v1.h.UpdateUserProfileImage(ctx, arg)
 	if err != nil {
-		err = _serviceErrorCheck(err)
+		if errors.Is(err, ErrNotFound) {
+			err = oservice.NewError(err, ErrNotFound.Error(), ErrCodeNotFound)
+		}
 		return
 	}
 	return

--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -30,6 +30,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -90,7 +91,11 @@ func main() {
 		var arg hello.ClockTimeRet
 		arg, err = stream.Read()
 		if err != nil {
-			log.Fatalln(err)
+			if errors.Is(err, hello.ErrThisIsATest) {
+				println("caught hello error this is a test")
+			} else {
+				log.Fatalln(err)
+			}
 		}
 
 		fmt.Printf("ClockTime: %s\n", arg.Ts.String())
@@ -108,7 +113,11 @@ func main() {
 
 		answer, err := bi.Read()
 		if err != nil {
-			log.Fatalln(err)
+			if errors.Is(err, hello.ErrThisIsATest) {
+				println("niranetrinaetrine")
+			} else {
+				log.Fatalln(err)
+			}
 		}
 
 		fmt.Printf("Answer: %s\n", answer.Answer)

--- a/examples/simple/hello/hello.orbit
+++ b/examples/simple/hello/hello.orbit
@@ -14,6 +14,7 @@ service {
         ret: {
             res []int `validate:"required,min=1"`
         }
+        errors: thisIsATest
     }
 
     call test {
@@ -27,6 +28,7 @@ service {
         }
         timeout: 500ms
         maxRetSize: 10K
+        errors: thisIsATest, iAmAnError
     }
 
     stream lul {}
@@ -39,6 +41,7 @@ service {
         ret: {
             ts time `validate:"required"`
         }
+        errors: thisIsATest, iAmAnError
     }
 
     stream bidirectional {

--- a/examples/simple/hello/hello.orbit
+++ b/examples/simple/hello/hello.orbit
@@ -52,6 +52,7 @@ service {
         ret: {
             answer string
         }
+        errors: thisIsATest
     }
 }
 

--- a/internal/codegen/ast/ast.go
+++ b/internal/codegen/ast/ast.go
@@ -112,6 +112,7 @@ type Call struct {
 	Timeout    *time.Duration
 	MaxArgSize *int64
 	MaxRetSize *int64
+	Errors     []*Error
 	lexer.Pos
 }
 
@@ -129,6 +130,7 @@ type Stream struct {
 	Ret        DataType
 	MaxArgSize *int64
 	MaxRetSize *int64
+	Errors     []*Error
 	lexer.Pos
 }
 

--- a/internal/codegen/gen/gen_service_call.go
+++ b/internal/codegen/gen/gen_service_call.go
@@ -113,8 +113,6 @@ func (g *generator) genClientCall(c *ast.Call, errs []*ast.Error) {
 			// Inline check for defined errors.
 			g.genClientErrorInlineCheck(c.Errors)
 		} else {
-			// Check for all errors.
-			g.writefLn("err = %s(err)", clientErrorCheck)
 			g.writeLn("return")
 		}
 	})
@@ -196,8 +194,6 @@ func (g *generator) genServiceCall(c *ast.Call) {
 			// Inline check for defined errors.
 			g.genServiceErrorInlineCheck(c.Errors)
 		} else {
-			// Check for all errors.
-			g.writefLn("err = %s(err)", serviceErrorCheck)
 			g.writeLn("return")
 		}
 	})

--- a/internal/codegen/gen/gen_service_call.go
+++ b/internal/codegen/gen/gen_service_call.go
@@ -109,8 +109,14 @@ func (g *generator) genClientCall(c *ast.Call, errs []*ast.Error) {
 
 	// Check error and parse control.ErrorCodes.
 	g.errIfNilFunc(func() {
-		g.writefLn("err = %s(err)", clientErrorCheck)
-		g.writeLn("return")
+		if len(c.Errors) != 0 {
+			// Inline check for defined errors.
+			g.genClientErrorInlineCheck(c.Errors)
+		} else {
+			// Check for all errors.
+			g.writefLn("err = %s(err)", clientErrorCheck)
+			g.writeLn("return")
+		}
 	})
 
 	// If return arguments were expected, validate them.
@@ -186,8 +192,14 @@ func (g *generator) genServiceCall(c *ast.Call) {
 
 	// Check error and convert to orbit errors.
 	g.errIfNilFunc(func() {
-		g.writefLn("err = %s(err)", serviceErrorCheck)
-		g.writeLn("return")
+		if len(c.Errors) != 0 {
+			// Inline check for defined errors.
+			g.genServiceErrorInlineCheck(c.Errors)
+		} else {
+			// Check for all errors.
+			g.writefLn("err = %s(err)", serviceErrorCheck)
+			g.writeLn("return")
+		}
 	})
 
 	// Assign return value.

--- a/internal/codegen/gen/gen_service_stream.go
+++ b/internal/codegen/gen/gen_service_stream.go
@@ -128,7 +128,12 @@ func (g *generator) genServiceStream(s *ast.Stream) {
 		g.writefLn("stream oservice.%s) (err error) {", typedStream(s, true))
 		g.writefLn("err = %s.h.%s(ctx, new%sServiceStream(stream))", recv, s.Ident(), s.Ident())
 		g.errIfNilFunc(func() {
-			g.writeLn("err = _serviceErrorCheck(err)")
+			if len(s.Errors) != 0 {
+				// Inline check for defined errors.
+				g.genServiceErrorInlineCheck(s.Errors)
+			} else {
+				g.writeLn("return")
+			}
 		})
 		g.writeLn("return")
 	}

--- a/internal/codegen/gen/gen_type.go
+++ b/internal/codegen/gen/gen_type.go
@@ -97,8 +97,6 @@ func (g *generator) genClientStreamType(s *ast.Stream) {
 				// Inline check for defined errors.
 				g.genClientErrorInlineCheck(s.Errors)
 			} else {
-				// Check for all errors.
-				g.writefLn("err = %s(err)", clientErrorCheck)
 				g.writeLn("return")
 			}
 		})
@@ -122,8 +120,6 @@ func (g *generator) genClientStreamType(s *ast.Stream) {
 				// Inline check for defined errors.
 				g.genClientErrorInlineCheck(s.Errors)
 			} else {
-				// Check for all errors.
-				g.writefLn("err = %s(err)", clientErrorCheck)
 				g.writeLn("return")
 			}
 		})
@@ -169,8 +165,6 @@ func (g *generator) genServiceStreamType(s *ast.Stream) {
 				// Inline check for defined errors.
 				g.genServiceErrorInlineCheck(s.Errors)
 			} else {
-				// Check for all errors.
-				g.writefLn("err = %s(err)", serviceErrorCheck)
 				g.writeLn("return")
 			}
 		})
@@ -194,8 +188,6 @@ func (g *generator) genServiceStreamType(s *ast.Stream) {
 				// Inline check for defined errors.
 				g.genServiceErrorInlineCheck(s.Errors)
 			} else {
-				// Check for all errors.
-				g.writefLn("err = %s(err)", serviceErrorCheck)
 				g.writeLn("return")
 			}
 		})

--- a/internal/codegen/gen/gen_type.go
+++ b/internal/codegen/gen/gen_type.go
@@ -89,11 +89,18 @@ func (g *generator) genClientStreamType(s *ast.Stream) {
 		g.writefLn("func (%s *%s) Read() (ret %s, err error) {", recv, name, s.Ret.Decl())
 		g.writefLn("err = %s.stream.Read(&ret)", recv)
 		g.errIfNilFunc(func() {
-			g.writefLn("err = %s(err)", clientErrorCheck)
 			g.writeLn("if errors.Is(err, oclient.ErrClosed) {")
 			g.writeLn("err = ErrClosed")
-			g.writeLn("}")
 			g.writeLn("return")
+			g.writeLn("}")
+			if len(s.Errors) != 0 {
+				// Inline check for defined errors.
+				g.genClientErrorInlineCheck(s.Errors)
+			} else {
+				// Check for all errors.
+				g.writefLn("err = %s(err)", clientErrorCheck)
+				g.writeLn("return")
+			}
 		})
 		// Validate, if needed.
 		g.writeValErrCheck(s.Ret, "ret")
@@ -107,11 +114,18 @@ func (g *generator) genClientStreamType(s *ast.Stream) {
 		g.writefLn("func (%s *%s) Write(arg %s) (err error) {", recv, name, s.Arg.Decl())
 		g.writefLn("err = %s.stream.Write(arg)", recv)
 		g.errIfNilFunc(func() {
-			g.writefLn("err = %s(err)", clientErrorCheck)
 			g.writeLn("if errors.Is(err, oclient.ErrClosed) {")
 			g.writeLn("err = ErrClosed")
-			g.writeLn("}")
 			g.writeLn("return")
+			g.writeLn("}")
+			if len(s.Errors) != 0 {
+				// Inline check for defined errors.
+				g.genClientErrorInlineCheck(s.Errors)
+			} else {
+				// Check for all errors.
+				g.writefLn("err = %s(err)", clientErrorCheck)
+				g.writeLn("return")
+			}
 		})
 		g.writeLn("return")
 		g.writeLn("}")
@@ -147,11 +161,18 @@ func (g *generator) genServiceStreamType(s *ast.Stream) {
 		g.writefLn("func (%s *%s) Read() (arg %s, err error) {", recv, name, s.Arg.Decl())
 		g.writefLn("err = %s.stream.Read(&arg)", recv)
 		g.errIfNilFunc(func() {
-			g.writefLn("err = %s(err)", serviceErrorCheck)
 			g.writeLn("if errors.Is(err, oservice.ErrClosed) {")
 			g.writeLn("err = ErrClosed")
-			g.writeLn("}")
 			g.writeLn("return")
+			g.writeLn("}")
+			if len(s.Errors) != 0 {
+				// Inline check for defined errors.
+				g.genServiceErrorInlineCheck(s.Errors)
+			} else {
+				// Check for all errors.
+				g.writefLn("err = %s(err)", serviceErrorCheck)
+				g.writeLn("return")
+			}
 		})
 		// Validate, if needed.
 		g.writeValErrCheck(s.Arg, "arg")
@@ -165,11 +186,18 @@ func (g *generator) genServiceStreamType(s *ast.Stream) {
 		g.writefLn("func (%s *%s) Write(ret %s) (err error) {", recv, name, s.Ret.Decl())
 		g.writefLn("err = %s.stream.Write(ret)", recv)
 		g.errIfNilFunc(func() {
-			g.writefLn("err = %s(err)", serviceErrorCheck)
 			g.writeLn("if errors.Is(err, oservice.ErrClosed) {")
 			g.writeLn("err = ErrClosed")
-			g.writeLn("}")
 			g.writeLn("return")
+			g.writeLn("}")
+			if len(s.Errors) != 0 {
+				// Inline check for defined errors.
+				g.genServiceErrorInlineCheck(s.Errors)
+			} else {
+				// Check for all errors.
+				g.writefLn("err = %s(err)", serviceErrorCheck)
+				g.writeLn("return")
+			}
 		})
 		g.writeLn("return")
 		g.writeLn("}")

--- a/internal/codegen/lexer/lexer_test.go
+++ b/internal/codegen/lexer/lexer_test.go
@@ -56,7 +56,7 @@ service{ asynct async ` + "maxArgSize``:" + `
 url
 /*service // bla blub 
 999 // /**/
-*/`
+*/errors: iAmAnError, anotherError,`
 
 	cases := []struct {
 		val  string
@@ -103,6 +103,12 @@ url
 		{val: "0B", typ: lexer.BYTESIZE, line: 10, col: 21},
 		{val: "0ns", typ: lexer.DURATION, line: 10, col: 24},
 		{val: "url", typ: lexer.IDENT, line: 12, col: 1},
+		{val: "errors", typ: lexer.ERRORS, line: 15, col: 3},
+		{val: ":", typ: lexer.COLON, line: 15, col: 9}, // 40
+		{val: "iAmAnError", typ: lexer.IDENT, line: 15, col: 11},
+		{val: ",", typ: lexer.COMMA, line: 15, col: 21},
+		{val: "anotherError", typ: lexer.IDENT, line: 15, col: 23},
+		{val: ",", typ: lexer.COMMA, line: 15, col: 35},
 	}
 
 	l := lexer.Lex(input)

--- a/internal/codegen/lexer/token.go
+++ b/internal/codegen/lexer/token.go
@@ -76,6 +76,7 @@ const (
 	RBRACK // ]
 	COLON  // :
 	EQUAL  // =
+	COMMA  // ,
 	delimEnd
 )
 
@@ -189,6 +190,7 @@ var delimTokenTypes = map[rune]TokenType{
 	']': RBRACK,
 	':': COLON,
 	'=': EQUAL,
+	',': COMMA,
 }
 
 func isDelim(r rune) (ok bool) {

--- a/internal/codegen/parser/parser_service.go
+++ b/internal/codegen/parser/parser_service.go
@@ -176,6 +176,35 @@ func (p *parser) expectServiceCall() (*ast.Call, []*ast.Type, error) {
 				return nil, nil, err
 			}
 			c.MaxRetSize = &size
+		} else if p.checkToken(lexer.ERRORS) {
+			// Check for duplicate.
+			if len(c.Errors) != 0 {
+				return nil, nil, p.errorf("duplicate errors")
+			}
+
+			// ':'.
+			err = p.expectToken(lexer.COLON)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// Expect a comma separated list of error identifiers.
+			for {
+				e := &ast.Error{Pos: p.tk.Pos}
+
+				// Error identifier.
+				e.Name, err = p.expectIdent()
+				if err != nil {
+					return nil, nil, err
+				}
+
+				c.Errors = append(c.Errors, e)
+
+				// If no comma follows, no more errors expected.
+				if !p.checkToken(lexer.COMMA) {
+					break
+				}
+			}
 		} else {
 			return nil, nil, p.errorf("unexpected token in service call '%s'", p.tk.Value)
 		}
@@ -300,6 +329,35 @@ func (p *parser) expectServiceStream() (*ast.Stream, []*ast.Type, error) {
 				return nil, nil, err
 			}
 			s.MaxRetSize = &size
+		} else if p.checkToken(lexer.ERRORS) {
+			// Check for duplicate.
+			if len(s.Errors) != 0 {
+				return nil, nil, p.errorf("duplicate errors")
+			}
+
+			// ':'.
+			err = p.expectToken(lexer.COLON)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// Expect a comma separated list of error identifiers.
+			for {
+				e := &ast.Error{Pos: p.tk.Pos}
+
+				// Error identifier.
+				e.Name, err = p.expectIdent()
+				if err != nil {
+					return nil, nil, err
+				}
+
+				s.Errors = append(s.Errors, e)
+
+				// If no comma follows, no more errors expected.
+				if !p.checkToken(lexer.COMMA) {
+					break
+				}
+			}
 		} else {
 			return nil, nil, p.errorf("unexpected token in service call '%s'", p.tk.Value)
 		}

--- a/internal/codegen/parser/parser_test.go
+++ b/internal/codegen/parser/parser_test.go
@@ -50,6 +50,9 @@ var (
 		Name: "c1",
 		Arg:  &ast.StructType{Name: "c1Arg"},
 		Ret:  &ast.StructType{Name: "c1Ret"},
+		Errors: []*ast.Error{
+			{Name: "theFirstError", Pos: lexer.Pos{Line: 11, Column: 15}},
+		},
 	}
 	c2 = &ast.Call{
 		Name:       "c2",
@@ -59,6 +62,10 @@ var (
 		Timeout:    &c2Timeout,
 		MaxArgSize: &c2MaxArgSize,
 		MaxRetSize: &c2MaxRetSize,
+		Errors: []*ast.Error{
+			{Name: "theFirstError", Pos: lexer.Pos{Line: 24, Column: 15}},
+			{Name: "theThirdError", Pos: lexer.Pos{Line: 24, Column: 30}},
+		},
 	}
 	c3  = &ast.Call{Name: "c3"}
 	rc1 = &ast.Call{
@@ -301,6 +308,7 @@ func requireEqualCall(t *testing.T, exp, act *ast.Call) {
 	require.Exactly(t, exp.Timeout, act.Timeout)
 	require.Exactly(t, exp.MaxArgSize, act.MaxArgSize)
 	require.Exactly(t, exp.MaxRetSize, act.MaxRetSize)
+	require.Exactly(t, exp.Errors, act.Errors)
 	requireEqualDataType(t, exp.Arg, act.Arg)
 	requireEqualDataType(t, exp.Ret, act.Ret)
 }

--- a/internal/codegen/parser/testdata/valid.orbit
+++ b/internal/codegen/parser/testdata/valid.orbit
@@ -8,6 +8,7 @@ service {
         ret: {
 			sum float32
 		}
+        errors: theFirstError
     }
     call c2 {
         async
@@ -20,6 +21,7 @@ service {
 		timeout: 500ms
 		maxArgSize: 154KB
 		maxRetSize: 5MiB
+        errors: theFirstError, theThirdError
     }
     call c3 {}
 

--- a/internal/codegen/validate/validate_test.go
+++ b/internal/codegen/validate/validate_test.go
@@ -29,6 +29,9 @@ func testValidateValid(t *testing.T) {
 			Name: "C1",
 			Arg:  &ast.StructType{Name: "C1Arg"},
 			Ret:  &ast.StructType{Name: "C1Ret"},
+			Errors: []*ast.Error{
+				{Name: "theFirstError", Pos: lexer.Pos{Line: 11, Column: 15}},
+			},
 		}
 		c2 = &ast.Call{
 			Name:       "C2",
@@ -38,6 +41,10 @@ func testValidateValid(t *testing.T) {
 			Timeout:    &c2Timeout,
 			MaxArgSize: &c2MaxArgSize,
 			MaxRetSize: &c2MaxRetSize,
+			Errors: []*ast.Error{
+				{Name: "theFirstError", Pos: lexer.Pos{Line: 24, Column: 15}},
+				{Name: "theThirdError", Pos: lexer.Pos{Line: 24, Column: 30}},
+			},
 		}
 		c3  = &ast.Call{Name: "C3"}
 		rc1 = &ast.Call{
@@ -239,4 +246,9 @@ func testValidateValid(t *testing.T) {
 	require.IsType(t, &ast.BaseType{}, rc1Ret.Fields[5].DataType.(*ast.MapType).Key)
 	require.IsType(t, &ast.BaseType{}, rc1Ret.Fields[5].DataType.(*ast.MapType).Value.(*ast.ArrType).Elem.(*ast.ArrType).Elem.(*ast.MapType).Key)
 	require.IsType(t, &ast.EnumType{}, rc1Ret.Fields[5].DataType.(*ast.MapType).Value.(*ast.ArrType).Elem.(*ast.ArrType).Elem.(*ast.MapType).Value)
+
+	// Check, if all errors have been resolved.
+	require.Exactly(t, 1, c1.Errors[0].ID)
+	require.Exactly(t, 1, c2.Errors[0].ID)
+	require.Exactly(t, 3, c2.Errors[1].ID)
 }


### PR DESCRIPTION
closes #67   
Adds the `errors:` block to call/stream definitions in `.orbit` files.  
It takes a comma separated list of error names that must be defined outside the `service` in `errors` blocks.  
The generated code then only checks against the defined errors