### PR TITLE
moved token types duration and bytesize from lexer into parser

### DIFF
--- a/internal/codegen/lexer/lexer_test.go
+++ b/internal/codegen/lexer/lexer_test.go
@@ -96,12 +96,12 @@ url
 		{val: "", typ: lexer.RAWSTRING, line: 9, col: 34},
 		{val: ":", typ: lexer.COLON, line: 9, col: 35}, // 30
 		{val: "-58", typ: lexer.INT, line: 10, col: 1},
-		{val: "1ms", typ: lexer.DURATION, line: 10, col: 5},
+		{val: "1ms", typ: lexer.IDENT, line: 10, col: 5},
 		{val: "0", typ: lexer.INT, line: 10, col: 9},
-		{val: "85MiB", typ: lexer.BYTESIZE, line: 10, col: 11},
+		{val: "85MiB", typ: lexer.IDENT, line: 10, col: 11},
 		{val: "999", typ: lexer.INT, line: 10, col: 17}, // 35
-		{val: "0B", typ: lexer.BYTESIZE, line: 10, col: 21},
-		{val: "0ns", typ: lexer.DURATION, line: 10, col: 24},
+		{val: "0B", typ: lexer.IDENT, line: 10, col: 21},
+		{val: "0ns", typ: lexer.IDENT, line: 10, col: 24},
 		{val: "url", typ: lexer.IDENT, line: 12, col: 1},
 		{val: "errors", typ: lexer.ERRORS, line: 15, col: 3},
 		{val: ":", typ: lexer.COLON, line: 15, col: 9}, // 40
@@ -136,10 +136,9 @@ func testLexerNextErr(t *testing.T) {
 	}{
 		{input: "`\ntest`", line: 1, col: 2}, // 0
 		{input: "`test", line: 1, col: 2},
-		{input: "-1a", line: 1, col: 1},
 		{input: "88MiB6", line: 1, col: 1},
 		{input: "-", line: 1, col: 1},
-		{input: "88.6", line: 1, col: 1}, // 5
+		{input: "88.6", line: 1, col: 1},
 	}
 
 	for i, c := range cases {

--- a/internal/codegen/lexer/states.go
+++ b/internal/codegen/lexer/states.go
@@ -29,10 +29,7 @@ package lexer
 
 import (
 	"strconv"
-	"time"
 	"unicode"
-
-	"code.cloudfoundry.org/bytefmt"
 )
 
 func lexTokenStart(l *lexer) stateFn {
@@ -178,25 +175,9 @@ func lexNumber(l *lexer) stateFn {
 		return lexTokenStart
 	}
 
-	// If the number contains non-digits, try to convert it to a byte size / duration.
-	// Try faster byte size first.
-	_, err := bytefmt.ToBytes(ci)
-	if err == nil {
-		// Valid.
-		l.emit(BYTESIZE)
-		return lexTokenStart
-	}
-
-	// Try duration.
-	_, err = time.ParseDuration(ci)
-	if err == nil {
-		// Valid.
-		l.emit(DURATION)
-		return lexTokenStart
-	}
-
-	// Invalid.
-	return l.errorf("invalid number literal: '%s'", ci)
+	// Treat a number with digits followed by chars as ident.
+	l.emit(IDENT)
+	return lexTokenStart
 }
 
 func lexLineComment(l *lexer) stateFn {

--- a/internal/codegen/lexer/token.go
+++ b/internal/codegen/lexer/token.go
@@ -42,8 +42,6 @@ const (
 	IDENT     // sendData
 	INT       // 123
 	RAWSTRING // `rawstring`
-	BYTESIZE  // 1MB
-	DURATION  // 80ns
 	literalEnd
 
 	// Keywords
@@ -93,10 +91,6 @@ func (tt TokenType) String() string {
 			return "int"
 		case RAWSTRING:
 			return "rawstring"
-		case BYTESIZE:
-			return "bytesize"
-		case DURATION:
-			return "duration"
 		}
 	} else if keywordBegin < tt && tt < keywordEnd {
 		for k, v := range keywordTokenTypes {

--- a/internal/codegen/parser/parser.go
+++ b/internal/codegen/parser/parser.go
@@ -88,8 +88,8 @@ func (p *parser) expectDuration() (time.Duration, error) {
 	err := p.next()
 	if err != nil {
 		return 0, err
-	} else if p.tk.Type != lexer.DURATION {
-		return 0, p.errorf("expected time duration, got %s", p.tk.Value)
+	} else if p.tk.Type != lexer.IDENT {
+		return 0, p.errorf("expected time duration identifier, got %s", p.tk.Value)
 	}
 
 	dur, err := time.ParseDuration(p.tk.Value)
@@ -112,8 +112,8 @@ func (p *parser) expectByteSize() (int64, error) {
 		}
 
 		return -1, nil
-	} else if p.tk.Type != lexer.BYTESIZE {
-		return 0, p.errorf("expected byte size, got %s", p.tk.Value)
+	} else if p.tk.Type != lexer.IDENT {
+		return 0, p.errorf("expected byte size identifier, got %s", p.tk.Value)
 	}
 
 	size, err := bytefmt.ToBytes(p.tk.Value)

--- a/internal/codegen/parser/parser_test.go
+++ b/internal/codegen/parser/parser_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	c2Timeout          = 500 * time.Millisecond
+	c2Timeout          = 1 * time.Minute
 	c2MaxArgSize int64 = 154 * 1024
 	c2MaxRetSize int64 = 5 * 1024 * 1024
 )

--- a/internal/codegen/parser/testdata/valid.orbit
+++ b/internal/codegen/parser/testdata/valid.orbit
@@ -18,7 +18,7 @@ service {
         ret: {
 			data []map[string][]Ret
 		}
-		timeout: 500ms
+		timeout: 1m
 		maxArgSize: 154KB
 		maxRetSize: 5MiB
         errors: theFirstError, theThirdError


### PR DESCRIPTION
the lexer tried to do a little bit too much here. It should not have to interpret data at all.  
Therefore, moved the duration and bytesize interpretation into the parser, where it belongs

closes #105 